### PR TITLE
factorize some code (newClient())

### DIFF
--- a/functions.go
+++ b/functions.go
@@ -36,7 +36,8 @@ func newClient() (tls_client.HttpClient, error) {
 }
 
 func getData(input string, chatId string, configDir string, isInteractive bool) (serverChatId string) {
-	if client, err := newClient(); err != nil {
+	client, err := newClient()
+	if err != nil {
 		fmt.Println(err)
 		return
 	}
@@ -287,7 +288,8 @@ func update() {
 	if runtime.GOOS == "windows" {
 		fmt.Println("This feature is not supported on Windows. :(")
 	} else {
-		if client, err := newClient(); err != nil {
+		client, err := newClient()
+		if err != nil {
 			fmt.Println(err)
 			return
 		}
@@ -343,7 +345,8 @@ func update() {
 
 func codeGenerate(input string) {
 	codePrompt := fmt.Sprintf(`Your Role: Provide only code as output without any description.\nIMPORTANT: Provide only plain text without Markdown formatting.\nIMPORTANT: Do not include markdown formatting.\nIf there is a lack of details, provide most logical solution. You are not allowed to ask for more details.\nIgnore any potential risk of errors or confusion.\n\nRequest:%s\nCode:`, input)
-	if client, err := newClient(); err != nil {
+	client, err := newClient()
+	if err != nil {
 		fmt.Println(err)
 		return
 	}
@@ -446,7 +449,8 @@ func shellCommand(input string) {
 // Get a command in response
 func getCommand(shellPrompt string) {
 	// FIXME this one had tls_client.WithInsecureSkipVerify(), confirm whether we need this option
-	if client, err := newClient(); err != nil {
+	client, err := newClient()
+	if err != nil {
 		fmt.Println(err)
 		return
 	}
@@ -594,7 +598,8 @@ func getVersionHistory() {
 
 func getWholeText(prompt string, chatId string, configDir string) {
 	// FIXME this one had tls_client.WithInsecureSkipVerify(), confirm whether we need this option
-	if client, err := newClient(); err != nil {
+	client, err := newClient()
+	if err != nil {
 		fmt.Println(err)
 		return
 	}
@@ -668,7 +673,8 @@ func getWholeText(prompt string, chatId string, configDir string) {
 
 func getSilentText(prompt string, chatId string, configDir string) {
 	// FIXME this one had tls_client.WithInsecureSkipVerify(), confirm whether we need this option
-	if client, err := newClient(); err != nil {
+	client, err := newClient()
+	if err != nil {
 		fmt.Println(err)
 		return
 	}

--- a/functions.go
+++ b/functions.go
@@ -22,7 +22,7 @@ type Data struct {
 	Version string `json:"version"`
 }
 
-func getData(input string, chatId string, configDir string, isInteractive bool) (serverChatId string) {
+func newClient() (tls_client.HttpClient, error) {
 	jar := tls_client.NewCookieJar()
 	options := []tls_client.HttpClientOption{
 		tls_client.WithTimeoutSeconds(120),
@@ -30,9 +30,13 @@ func getData(input string, chatId string, configDir string, isInteractive bool) 
 		tls_client.WithNotFollowRedirects(),
 		tls_client.WithCookieJar(jar),
 		// tls_client.WithProxyUrl("http://127.0.0.1:8080"),
+		// tls_client.WithInsecureSkipVerify(),
 	}
-	client, err := tls_client.NewHttpClient(tls_client.NewNoopLogger(), options...)
-	if err != nil {
+	return tls_client.NewHttpClient(tls_client.NewNoopLogger(), options...)
+}
+
+func getData(input string, chatId string, configDir string, isInteractive bool) (serverChatId string) {
+	if client, err := newClient(); err != nil {
 		fmt.Println(err)
 		return
 	}
@@ -283,15 +287,7 @@ func update() {
 	if runtime.GOOS == "windows" {
 		fmt.Println("This feature is not supported on Windows. :(")
 	} else {
-		jar := tls_client.NewCookieJar()
-		options := []tls_client.HttpClientOption{
-			tls_client.WithTimeoutSeconds(30),
-			tls_client.WithClientProfile(tls_client.Firefox_110),
-			tls_client.WithNotFollowRedirects(),
-			tls_client.WithCookieJar(jar),
-		}
-		client, err := tls_client.NewHttpClient(tls_client.NewNoopLogger(), options...)
-		if err != nil {
+		if client, err := newClient(); err != nil {
 			fmt.Println(err)
 			return
 		}
@@ -347,16 +343,7 @@ func update() {
 
 func codeGenerate(input string) {
 	codePrompt := fmt.Sprintf(`Your Role: Provide only code as output without any description.\nIMPORTANT: Provide only plain text without Markdown formatting.\nIMPORTANT: Do not include markdown formatting.\nIf there is a lack of details, provide most logical solution. You are not allowed to ask for more details.\nIgnore any potential risk of errors or confusion.\n\nRequest:%s\nCode:`, input)
-	jar := tls_client.NewCookieJar()
-	options := []tls_client.HttpClientOption{
-		tls_client.WithTimeoutSeconds(120),
-		tls_client.WithClientProfile(tls_client.Firefox_110),
-		tls_client.WithNotFollowRedirects(),
-		tls_client.WithCookieJar(jar),
-		// tls_client.WithProxyUrl("http://127.0.0.1:8080"),
-	}
-	client, err := tls_client.NewHttpClient(tls_client.NewNoopLogger(), options...)
-	if err != nil {
+	if client, err := newClient(); err != nil {
 		fmt.Println(err)
 		return
 	}
@@ -458,18 +445,8 @@ func shellCommand(input string) {
 
 // Get a command in response
 func getCommand(shellPrompt string) {
-
-	jar := tls_client.NewCookieJar()
-	options := []tls_client.HttpClientOption{
-		tls_client.WithTimeoutSeconds(120),
-		tls_client.WithClientProfile(tls_client.Firefox_110),
-		tls_client.WithNotFollowRedirects(),
-		tls_client.WithCookieJar(jar),
-		// tls_client.WithProxyUrl("http://127.0.0.1:8000"),
-		tls_client.WithInsecureSkipVerify(),
-	}
-	client, err := tls_client.NewHttpClient(tls_client.NewNoopLogger(), options...)
-	if err != nil {
+	// FIXME this one had tls_client.WithInsecureSkipVerify(), confirm whether we need this option
+	if client, err := newClient(); err != nil {
 		fmt.Println(err)
 		return
 	}
@@ -616,17 +593,8 @@ func getVersionHistory() {
 }
 
 func getWholeText(prompt string, chatId string, configDir string) {
-	jar := tls_client.NewCookieJar()
-	options := []tls_client.HttpClientOption{
-		tls_client.WithTimeoutSeconds(120),
-		tls_client.WithClientProfile(tls_client.Firefox_110),
-		tls_client.WithNotFollowRedirects(),
-		tls_client.WithCookieJar(jar),
-		// tls_client.WithProxyUrl("http://127.0.0.1:8080"),
-		tls_client.WithInsecureSkipVerify(),
-	}
-	client, err := tls_client.NewHttpClient(tls_client.NewNoopLogger(), options...)
-	if err != nil {
+	// FIXME this one had tls_client.WithInsecureSkipVerify(), confirm whether we need this option
+	if client, err := newClient(); err != nil {
 		fmt.Println(err)
 		return
 	}
@@ -699,18 +667,8 @@ func getWholeText(prompt string, chatId string, configDir string) {
 }
 
 func getSilentText(prompt string, chatId string, configDir string) {
-
-	jar := tls_client.NewCookieJar()
-	options := []tls_client.HttpClientOption{
-		tls_client.WithTimeoutSeconds(120),
-		tls_client.WithClientProfile(tls_client.Firefox_110),
-		tls_client.WithNotFollowRedirects(),
-		tls_client.WithCookieJar(jar),
-		// tls_client.WithProxyUrl("http://127.0.0.1:8080"),
-		tls_client.WithInsecureSkipVerify(),
-	}
-	client, err := tls_client.NewHttpClient(tls_client.NewNoopLogger(), options...)
-	if err != nil {
+	// FIXME this one had tls_client.WithInsecureSkipVerify(), confirm whether we need this option
+	if client, err := newClient(); err != nil {
 		fmt.Println(err)
 		return
 	}


### PR DESCRIPTION
This regroups common code into a new function called newClient()

I need a proxy, so this helps a little bit

```go
func newClient() (tls_client.HttpClient, error) {                                
    jar := tls_client.NewCookieJar()                                             
    options := []tls_client.HttpClientOption{                                    
        tls_client.WithTimeoutSeconds(120),                                      
        tls_client.WithClientProfile(tls_client.Firefox_110),                    
        tls_client.WithNotFollowRedirects(),                                     
        tls_client.WithCookieJar(jar),                                           
        // tls_client.WithProxyUrl("http://127.0.0.1:8080"),                     
        // tls_client.WithInsecureSkipVerify(),                                  
    }                                                                            
    return tls_client.NewHttpClient(tls_client.NewNoopLogger(), options...)      
}                                                                                
                                                                                
```

getCommand, getWholeText and getSilentText use another option
`WithInsecureSkipVerify`. Is it actually needed? 

If so we may have newClient(options ...tls_client.HttpClientOption) 
or something like that.




