### PR TITLE
take proxy.txt out from source control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 tgpt
 build
+proxy.txt


### PR DESCRIPTION
For contributors maybe it is better if the file proxy.txt
is not part of the repository. This way I think it would avoid 
conflicts (if you changed that file) and facilitate PR.

The other users can easily create that file if they need it
by following the README. 

Tell me if I haven't thought of something.
