### PR TITLE
add copy and paste shortcuts to multiline mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/aandrew-me/tgpt/v2
 go 1.20
 
 require (
+	github.com/atotto/clipboard v0.1.4
 	github.com/bogdanfinn/fhttp v0.5.24
 	github.com/bogdanfinn/tls-client v1.6.1
 	github.com/c-bata/go-prompt v0.2.6
@@ -16,7 +17,6 @@ require (
 
 require (
 	github.com/andybalholm/brotli v1.0.5 // indirect
-	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/bogdanfinn/utls v1.5.16 // indirect
 	github.com/charmbracelet/lipgloss v0.8.0 // indirect

--- a/helper.go
+++ b/helper.go
@@ -34,7 +34,7 @@ type ImgResponse struct {
 	Images []string `json:"images"`
 }
 
-func getData(input string, isInteractive bool, prevMessages string) string {
+func getDataResponseTxt(input string, isInteractive bool, prevMessages string) string {
 	// Receiving response
 	resp, err := providers.NewRequest(input, structs.Params{ApiKey: *apiKey, ApiModel: *apiModel, Provider: *provider, Max_length: *max_length, Temperature: *temperature, Top_p: *top_p, Preprompt: *preprompt}, prevMessages)
 
@@ -71,7 +71,11 @@ func getData(input string, isInteractive bool, prevMessages string) string {
 	}
 
 	// Handling each part
-	responseTxt := handleEachPart(resp)
+	return handleEachPart(resp)
+}
+
+func getData(input string, isInteractive bool, prevMessages string) (string, string) {
+	responseTxt := getDataResponseTxt(input, isInteractive, prevMessages)
 	safeResponse, _ := json.Marshal(responseTxt)
 
 	fmt.Print("\n\n")
@@ -86,7 +90,7 @@ func getData(input string, isInteractive bool, prevMessages string) string {
 	},
 	`, string(safeInput), string(safeResponse))
 
-	return msgObject
+	return msgObject, responseTxt
 }
 
 func loading(stop *bool) {
@@ -690,8 +694,6 @@ func downloadImage(url string, destDir string, filename string) error {
 		return err
 	}
 	defer file.Close()
-
-
 
 	_, err = io.Copy(file, response.Body)
 	if err != nil {


### PR DESCRIPTION
Added copy and paste keybindings to multiline mode.
- i - focus the textarea
- y - copy last response to clipboard
- p - paste clipboard to textarea

These keybindings are only proccessed while the textarea is unfocused.

It uses this library https://github.com/atotto/clipboard.

Using the shortcuts to copy and paste between tgpt windows:

https://github.com/aandrew-me/tgpt/assets/147658676/29a9e46e-eacc-4f63-9683-f583cc56a62f