### PR TITLE
Added "B" shortcut to copy last block of code in multiline mode

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -442,6 +442,34 @@ func getWholeText(input string) {
 	fmt.Println(fullText)
 }
 
+func getLastCodeBlock(markdown string) string {
+	lines := strings.Split(markdown, "\n")
+	var codeBlock []string
+	capturing := false
+
+	for i := len(lines) - 1; i >= 0; i-- {
+		if strings.HasPrefix(lines[i], "```") {
+			if capturing {
+				capturing = false
+				break
+			} else {
+				capturing = true
+				continue
+			}
+		}
+		if capturing {
+			codeBlock = append([]string{lines[i]}, codeBlock...)
+		}
+	}
+
+	// If no code block is found, return an empty string.
+	if capturing || len(codeBlock) == 0 {
+		return ""
+	}
+
+	return strings.Join(codeBlock, "\n")
+}
+
 func getSilentText(input string) {
 	checkInputLength(input)
 

--- a/main.go
+++ b/main.go
@@ -245,8 +245,7 @@ func main() {
 			// Multiline interactive
 			/////////////////////
 
-			fmt.Print("\nPress Tab to submit, Ctrl + C to exit, Esc to unfocus, i to focus. When unfocused, press p to paste and c to copy response\n")
-
+			fmt.Print("\nPress Tab to submit, Ctrl + C to exit, Esc to unfocus, i to focus. When unfocused, press p to paste, c to copy response, bc to copy last code block in response\n")
 
 			previousMessages := ""
 
@@ -376,6 +375,15 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					break
 				}
 				err := clipboard.WriteAll(lastResponse)
+				if err != nil {
+					fmt.Println("Could not write to clipboard")
+				}
+			case "b":
+				if len(lastResponse) == 0 {
+					break
+				}
+				lastCodeBlock := getLastCodeBlock(lastResponse)
+				err := clipboard.WriteAll(lastCodeBlock)
 				if err != nil {
 					fmt.Println("Could not write to clipboard")
 				}

--- a/main.go
+++ b/main.go
@@ -245,7 +245,7 @@ func main() {
 			// Multiline interactive
 			/////////////////////
 
-			fmt.Print("\nPress Tab to submit, Ctrl + C to exit, Esc to unfocus, i to focus. When unfocused, press p to paste, c to copy response, bc to copy last code block in response\n")
+			fmt.Print("\nPress Tab to submit, Ctrl + C to exit, Esc to unfocus, i to focus. When unfocused, press p to paste, c to copy response, b to copy last code block in response\n")
 
 			previousMessages := ""
 


### PR DESCRIPTION
I use `tgpt -m` to generate and refine code, and I need to copy code blocks pretty frequently. This PR adds a shortcut ("B") to copy the last code block in the last response of multiline mode.


https://github.com/aandrew-me/tgpt/assets/147658676/17630aa7-4026-47d7-a713-3617af7a9918

