### PR TITLE
Autogrow textarea in interactive mode

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
             - name: Set up Go
               uses: actions/setup-go@v2
               with:
-                  go-version: "1.20.x"
+                  go-version: "^1.22.1"
 
             - name: Linux
               if: matrix.os == 'ubuntu-20.04'

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aandrew-me/tgpt/v2
 
-go 1.20
+go 1.22.1
 
 require (
 	github.com/atotto/clipboard v0.1.4

--- a/main.go
+++ b/main.go
@@ -389,6 +389,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		default:
 			if m.textarea.Focused() {
 				m.textarea, cmd = m.textarea.Update(msg)
+				m.textarea.SetHeight(min(20, max(6, m.textarea.LineCount()+1)))
 				cmds = append(cmds, cmd)
 			}
 		}
@@ -424,6 +425,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 				userInput = clip
 				m.textarea, cmd = m.textarea.Update(msg)
+				m.textarea.SetHeight(min(20, max(6, m.textarea.LineCount()+1)))
 				cmds = append(cmds, cmd)
 			}
 		}


### PR DESCRIPTION
The default text area has a fixed height of 6 lines which can be a little inconvenient when working with code examples etc. I find it useful if the text area grows automatically (up to a height of 20 rows).

[Screencast from 2024-03-23 11-32-10.webm](https://github.com/aandrew-me/tgpt/assets/3457747/13179855-2c3e-4f1e-9313-01f4be79df31)


The PR also upgrade go version to 1.22.1. Go 1.21 is required for this PR because it uses the newly builtin `min` and `max` functions.
