### PR TITLE
UPDATE: add url field in struct Params for openai provider

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -44,6 +44,7 @@ func getDataResponseTxt(input string, isInteractive bool, extraOptions structs.E
 		Temperature: *temperature,
 		Top_p:       *top_p,
 		Preprompt:   *preprompt,
+		Url:         *url,
 	}, extraOptions)
 
 	if err != nil {
@@ -202,7 +203,7 @@ func codeGenerate(input string) {
 
 	codePrompt := fmt.Sprintf("Your Role: Provide only code as output without any description.\nIMPORTANT: Provide only plain text without Markdown formatting.\nIMPORTANT: Do not include markdown formatting.\nIf there is a lack of details, provide most logical solution. You are not allowed to ask for more details.\nIgnore any potential risk of errors or confusion.\n\nRequest:%s\nCode:", input)
 
-	resp, err := providers.NewRequest(codePrompt, structs.Params{ApiKey: *apiKey, ApiModel: *apiModel, Provider: *provider, Max_length: *max_length, Temperature: *temperature, Top_p: *top_p, Preprompt: *preprompt}, structs.ExtraOptions{})
+	resp, err := providers.NewRequest(codePrompt, structs.Params{ApiKey: *apiKey, ApiModel: *apiModel, Provider: *provider, Max_length: *max_length, Temperature: *temperature, Top_p: *top_p, Preprompt: *preprompt, Url: *url}, structs.ExtraOptions{})
 
 	if err != nil {
 		stopSpin = true
@@ -282,7 +283,7 @@ func shellCommand(input string) {
 func getCommand(shellPrompt string) {
 	checkInputLength(shellPrompt)
 
-	resp, err := providers.NewRequest(shellPrompt, structs.Params{ApiKey: *apiKey, ApiModel: *apiModel, Provider: *provider, Max_length: *max_length, Temperature: *temperature, Top_p: *top_p, Preprompt: *preprompt}, structs.ExtraOptions{})
+	resp, err := providers.NewRequest(shellPrompt, structs.Params{ApiKey: *apiKey, ApiModel: *apiModel, Provider: *provider, Max_length: *max_length, Temperature: *temperature, Top_p: *top_p, Preprompt: *preprompt, Url: *url}, structs.ExtraOptions{})
 
 	if err != nil {
 		stopSpin = true
@@ -324,7 +325,7 @@ func getCommand(shellPrompt string) {
 		bold.Print("\n\nExecute shell command? [y/n]: ")
 		reader := bufio.NewReader(os.Stdin)
 		userInput, _ := reader.ReadString('\n')
-		userInput = strings.TrimSpace(userInput) 
+		userInput = strings.TrimSpace(userInput)
 		if userInput == "y" || userInput == "" {
 			var cmd *exec.Cmd
 			if runtime.GOOS == "windows" {
@@ -409,7 +410,7 @@ func getVersionHistory() {
 func getWholeText(input string) {
 	checkInputLength(input)
 
-	resp, err := providers.NewRequest(input, structs.Params{ApiKey: *apiKey, ApiModel: *apiModel, Provider: *provider, Max_length: *max_length, Temperature: *temperature, Top_p: *top_p, Preprompt: *preprompt}, structs.ExtraOptions{})
+	resp, err := providers.NewRequest(input, structs.Params{ApiKey: *apiKey, ApiModel: *apiModel, Provider: *provider, Max_length: *max_length, Temperature: *temperature, Top_p: *top_p, Preprompt: *preprompt, Url: *url}, structs.ExtraOptions{})
 
 	if err != nil {
 		stopSpin = true
@@ -474,7 +475,7 @@ func getLastCodeBlock(markdown string) string {
 func getSilentText(input string) {
 	checkInputLength(input)
 
-	resp, err := providers.NewRequest(input, structs.Params{ApiKey: *apiKey, ApiModel: *apiModel, Provider: *provider, Max_length: *max_length, Temperature: *temperature, Top_p: *top_p, Preprompt: *preprompt}, structs.ExtraOptions{})
+	resp, err := providers.NewRequest(input, structs.Params{ApiKey: *apiKey, ApiModel: *apiModel, Provider: *provider, Max_length: *max_length, Temperature: *temperature, Top_p: *top_p, Preprompt: *preprompt, Url: *url}, structs.ExtraOptions{})
 
 	if err != nil {
 		stopSpin = true

--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ var temperature *string
 var top_p *string
 var max_length *string
 var preprompt *string
+var url *string
 
 func main() {
 	execPath, err := os.Executable()
@@ -63,6 +64,7 @@ func main() {
 	top_p = flag.String("top_p", "", "Set top_p")
 	max_length = flag.String("max_length", "", "Set max length of response")
 	preprompt = flag.String("preprompt", "", "Set preprompt")
+	url = flag.String("url", "https://api.openai.com/v1/chat/completions", "url for openai providers")
 
 	isQuiet := flag.Bool("q", false, "Gives response back without loading animation")
 	flag.BoolVar(isQuiet, "quiet", false, "Gives response back without loading animation")

--- a/providers/openai/openai.go
+++ b/providers/openai/openai.go
@@ -34,12 +34,12 @@ func NewRequest(input string, params structs.Params, prevMessages string) (*http
 	}
 
 	temperature := "0.5"
-	if params.Temperature != ""{
+	if params.Temperature != "" {
 		temperature = params.Temperature
 	}
 
 	top_p := "0.5"
-	if params.Top_p != ""{
+	if params.Top_p != "" {
 		top_p = params.Top_p
 	}
 
@@ -62,7 +62,7 @@ func NewRequest(input string, params structs.Params, prevMessages string) (*http
 	}
 	`, prevMessages, string(safeInput), model, temperature, top_p))
 
-	req, err := http.NewRequest("POST", "https://api.openai.com/v1/chat/completions", data)
+	req, err := http.NewRequest("POST", params.Url, data)
 	if err != nil {
 		fmt.Println("\nSome error has occurred.")
 		fmt.Println("Error:", err)
@@ -70,8 +70,7 @@ func NewRequest(input string, params structs.Params, prevMessages string) (*http
 	}
 	// Setting all the required headers
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer " + params.ApiKey)
-
+	req.Header.Set("Authorization", "Bearer "+params.ApiKey)
 	// Return response
 	return (client.Do(req))
 }

--- a/structs/structs.go
+++ b/structs/structs.go
@@ -9,6 +9,7 @@ type Params struct {
 	Max_length  string
 	Preprompt   string
 	ThreadID    string
+	Url         string
 }
 
 type ExtraOptions struct {


### PR DESCRIPTION
 Add url field in struct Params for openai provider, used for other OpenAI-compatible model or endpoint, like OpenAI API proxy, [openai-gemini](https://github.com/PublicAffairs/openai-gemini).