### PR TITLE
fix the borken provider openai in v2.7.3

### DIFF
--- a/providers/openai/openai.go
+++ b/providers/openai/openai.go
@@ -94,7 +94,7 @@ func GetMainText(line string) (mainText string) {
 		return ""
 	}
 
-	if d.Choices != nil {
+	if d.Choices != nil && len(d.Choices) > 0 {
 		mainText = d.Choices[0].Delta.Content
 		return mainText
 	}

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -24,9 +24,9 @@ func GetMainText(line string, provider string, input string) string {
 	if provider == "opengpts" {
 		return opengpts.GetMainText(line, input)
 	} else if provider == "openai" {
-		return ollama.GetMainText(line)
-	} else if provider == "ollama" {
 		return openai.GetMainText(line)
+	} else if provider == "ollama" {
+		return ollama.GetMainText(line)
 	} else if provider == "koboldai" {
 		return koboldai.GetMainText(line)
 	} else if provider == "phind" {


### PR DESCRIPTION
Commit-1: fix this,
https://github.com/aandrew-me/tgpt/blob/22015a0d036748e02c7bc5fbb480856925a89151/providers/providers.go#L26-L29

Commit-2: fix an index error of openai Response

```
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/aandrew-me/tgpt/v2/providers/openai.GetMainText({0xc000126840?, 0x142?})
	/tmp/tgpt/src/tgpt-2.7.3/providers/openai/openai.go:98 +0xdb
github.com/aandrew-me/tgpt/v2/providers.GetMainText({0xc000126840?, 0xc0002a1000?}, {0x7fffda6c3346?, 0xc000132080?}, {0xc00021a03b?, 0x0?})
....
```

Response:

```
data: {"choices":[],"created":0,"id":"","model":"","object":"","prompt_filter_results":[{"prompt_index":0,"content_filter_results":{"hate":{"filtered":false,"severity":"safe"},"self_harm":{"filtered":false,"severity":"safe"},"sexual":{"filtered":false,"severity":"safe"},"violence":{"filtered":false,"severity":"safe"}}}]}
```