### PR TITLE
Tweak build script (build.sh).

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,38 +4,42 @@ echo "
 1). Build for Linux
 2). Build for Windows
 3). Build for MacOS
-4). Build for Linux, Windows and MacOS"
+4). Build for Linux, Windows and MacOS
+5). Quit
+"
 
-read -p "Please choose One [ 1-4 ]: " chs
-if [[ $chs == "1" ]]; then
-  # For GNU Linux
-  GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o ./build/tgpt-linux-amd64
-  GOARCH=386 go build -trimpath -ldflags="-s -w" -o ./build/tgpt-linux-i386
-  GOARCH=arm64 go build -trimpath -ldflags="-s -w" -o ./build/tgpt-linux-arm64
-elif [[ $chs == "2" ]]; then
-  # For Windows
-  GOOS=windows GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o ./build/tgpt-amd64.exe
-  GOOS=windows GOARCH=386 go build -trimpath -ldflags="-s -w" -o ./build/tgpt-i386.exe
-  GOOS=windows GOARCH=arm64 go build -trimpath -ldflags="-s -w" -o ./build/tgpt-arm64.exe
-elif [[ $chs == "3" ]]; then
-  # For MacOS
-  GOOS=darwin GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o ./build/tgpt-mac-amd64
-  GOOS=darwin GOARCH=arm64 go build -trimpath -ldflags="-s -w" -o ./build/tgpt-mac-arm64
-elif [[ $chs == "4" ]]; then
-  # For GNU Linux
-  GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o ./build/tgpt-linux-amd64
-  GOARCH=386 go build -trimpath -ldflags="-s -w" -o ./build/tgpt-linux-i386
-  GOARCH=arm64 go build -trimpath -ldflags="-s -w" -o ./build/tgpt-linux-arm64
+read -rp "Please choose One [ 1-5 ]: " -n 1 chs
+if [[ "$chs" == "1" ]]; then
+	# For GNU Linux
+	GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o ./build/tgpt-linux-amd64
+	GOARCH=386 go build -trimpath -ldflags="-s -w" -o ./build/tgpt-linux-i386
+	GOARCH=arm64 go build -trimpath -ldflags="-s -w" -o ./build/tgpt-linux-arm64
+elif [[ "$chs" == "2" ]]; then
+	# For Windows
+	GOOS=windows GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o ./build/tgpt-amd64.exe
+	GOOS=windows GOARCH=386 go build -trimpath -ldflags="-s -w" -o ./build/tgpt-i386.exe
+	GOOS=windows GOARCH=arm64 go build -trimpath -ldflags="-s -w" -o ./build/tgpt-arm64.exe
+elif [[ "$chs" == "3" ]]; then
+	# For MacOS
+	GOOS=darwin GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o ./build/tgpt-mac-amd64
+	GOOS=darwin GOARCH=arm64 go build -trimpath -ldflags="-s -w" -o ./build/tgpt-mac-arm64
+elif [[ "$chs" == "4" ]]; then
+	# For GNU Linux
+	GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o ./build/tgpt-linux-amd64
+	GOARCH=386 go build -trimpath -ldflags="-s -w" -o ./build/tgpt-linux-i386
+	GOARCH=arm64 go build -trimpath -ldflags="-s -w" -o ./build/tgpt-linux-arm64
 
-  # For Windows
-  GOOS=windows GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o ./build/tgpt-amd64.exe
-  GOOS=windows GOARCH=386 go build -trimpath -ldflags="-s -w" -o ./build/tgpt-i386.exe
-  GOOS=windows GOARCH=arm64 go build -trimpath -ldflags="-s -w" -o ./build/tgpt-arm64.exe
+	# For Windows
+	GOOS=windows GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o ./build/tgpt-amd64.exe
+	GOOS=windows GOARCH=386 go build -trimpath -ldflags="-s -w" -o ./build/tgpt-i386.exe
+	GOOS=windows GOARCH=arm64 go build -trimpath -ldflags="-s -w" -o ./build/tgpt-arm64.exe
 
-  # For MacOS
-  GOOS=darwin GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o ./build/tgpt-mac-amd64
-  GOOS=darwin GOARCH=arm64 go build -trimpath -ldflags="-s -w" -o ./build/tgpt-mac-arm64
+	# For MacOS
+	GOOS=darwin GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o ./build/tgpt-mac-amd64
+	GOOS=darwin GOARCH=arm64 go build -trimpath -ldflags="-s -w" -o ./build/tgpt-mac-arm64
+elif [[ "$chs" == "5" ]]; then
+	exit 0
 else
-  echo "Invalid Options !"
-  exit 1
+	echo "Invalid Options !"
+	exit 1
 fi

--- a/build.sh
+++ b/build.sh
@@ -5,10 +5,10 @@ echo "
 2). Build for Windows
 3). Build for MacOS
 4). Build for Linux, Windows and MacOS
-5). Quit
+0). Quit
 "
 
-read -rp "Please choose One [ 1-5 ]: " -n 1 chs
+read -rp "Please choose One [ 0-4 ]: " -n 1 chs
 if [[ "$chs" == "1" ]]; then
 	# For GNU Linux
 	GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o ./build/tgpt-linux-amd64
@@ -37,7 +37,7 @@ elif [[ "$chs" == "4" ]]; then
 	# For MacOS
 	GOOS=darwin GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o ./build/tgpt-mac-amd64
 	GOOS=darwin GOARCH=arm64 go build -trimpath -ldflags="-s -w" -o ./build/tgpt-mac-arm64
-elif [[ "$chs" == "5" ]]; then
+elif [[ "$chs" == "0" ]]; then
 	exit 0
 else
 	echo "Invalid Options !"


### PR DESCRIPTION
Tweaked the `build.sh` build script, probably.  
1. Reinforced the `if`s (using string expression instead of numerical expression for `$chs`). 
2. Adds `-rn 1` to `read`, which gives a more friendly interface (treat '`\`' normally, and ends immediately when the user enters one char).  
3. Adds `5). Quit` option.  
4. Makes the code slightly more readable (use '`\t`' instead of '`  `')