### PR TITLE
change log.txt to pointer *logFile (argument for --log flag)

### DIFF
--- a/main.go
+++ b/main.go
@@ -253,7 +253,7 @@ func main() {
 							os.Exit(0)
 						}
 						if len(*logFile) > 0 {
-							utils.LogToFile(input, "USER_QUERY", "log.txt")
+							utils.LogToFile(input, "USER_QUERY", *logFile)
 						}
 						// Use preprompt for first message
 						if previousMessages == "" {
@@ -265,7 +265,7 @@ func main() {
 							Provider:     *provider,
 						})
 						if len(*logFile) > 0 {
-							utils.LogToFile(responseTxt, "ASSISTANT_RESPONSE", "log.txt")
+							utils.LogToFile(responseTxt, "ASSISTANT_RESPONSE", *logFile)
 						}
 						previousMessages += responseJson
 						history = append(history, input)
@@ -295,7 +295,7 @@ func main() {
 				}
 				if len(userInput) > 0 {
 					if len(*logFile) > 0 {
-						utils.LogToFile(userInput, "USER_QUERY", "log.txt")
+						utils.LogToFile(userInput, "USER_QUERY", *logFile)
 					}
 
 					responseJson, responseTxt := getData(userInput, true, structs.ExtraOptions{
@@ -308,7 +308,7 @@ func main() {
 					lastResponse = responseTxt
 
 					if len(*logFile) > 0 {
-						utils.LogToFile(responseTxt, "ASSISTANT_RESPONSE", "log.txt")
+						utils.LogToFile(responseTxt, "ASSISTANT_RESPONSE", *logFile)
 					}
 				}
 


### PR DESCRIPTION
i noticed that the argument for the logfile path is ignored and instead the logfile is always created in the current directory. so i checked the code and saw that you forgot to replace "log.txt", probably for testing purposes, with the actual pointer variable