### PR TITLE
FreeBSD port of tgpt is now available in quarterly repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,6 @@ yay -S tgpt-bin
 
 ### FreeBSD 😈 
 
-Currently, the port is not yet in the quarterly branch of the FreeBSD ports tree.
-
 To install the [port](https://www.freshports.org/www/tgpt):
 ```
 cd /usr/ports/www/tgpt/ && make install clean


### PR DESCRIPTION
FreeBSD port of tgpt is now available in quarterly repositories so I removed the note about package availability in quarterly repositories of FreeBSD.

![2024-07-14_13-42](https://github.com/user-attachments/assets/44fb4a91-88e0-4614-b289-64a86ec79615)
