### PR TITLE
feat: implement storing proxy config file in a common directory (#277)

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -32,9 +32,11 @@ func NewClient() (tls_client.HttpClient, error) {
 			options = append(options, proxyOption)
 		}
 	} else {
+		homeDir, _ := os.UserHomeDir()
+
 		proxyConfigLocations := []string{
 			"proxy.txt",
-			filepath.Join(os.Getenv("HOME"), ".config", "tgpt", "proxy.txt"),
+			filepath.Join(homeDir, ".config", "tgpt", "proxy.txt"),
 		}
 
 		for _, proxyConfigLocation := range proxyConfigLocations {


### PR DESCRIPTION
This PR adds proxy configuration storage in a common directory.

now tgpt obtains proxy configuration data from the following sources in the following order:

1. current directory (proxy.txt)
2. user's config directory (~/.config/tgpt/proxy.txt)

resolve #277 