### PR TITLE
Added GPT-4-mini, from duckduckgo\'s endpoint. Changed default user-agent to "Linux" too (we gotta contribute to making `linux`'s marketshare be bigger in the pie charts!)

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -700,7 +700,7 @@ func generateImage(prompt string) {
 	req, _ := http.NewRequest("POST", url, payload)
 
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:99.0) Gecko/20100101 Firefox/110.0")
+	req.Header.Set("User-Agent", "Mozilla/5.0 (X11; Linux x86_64; rv:127.0) Gecko/20100101 Firefox/127.0")
 
 	res, err := client.Do(req)
 
@@ -782,17 +782,18 @@ func addToShellHistory(command string) {
 	shell := os.Getenv("SHELL")
 	homeDir := os.Getenv("HOME")
 
-	if strings.Contains(shell, "/bash")  {
+	if strings.Contains(shell, "/bash") {
 		historyPath := os.Getenv("HISTFILE")
 
 		if historyPath == "" {
-			historyPath = homeDir + "/.bash_history";
+			historyPath = homeDir + "/.bash_history"
 		}
 
-        file, err := os.OpenFile(historyPath, os.O_APPEND|os.O_WRONLY, 0644)
-        if err!= nil {}
-        defer file.Close()
+		file, err := os.OpenFile(historyPath, os.O_APPEND|os.O_WRONLY, 0644)
+		if err != nil {
+		}
+		defer file.Close()
 
-        _, err = file.WriteString(command + "\n")
+		_, err = file.WriteString(command + "\n")
 	}
 }

--- a/providers/duckduckgo/duckduckgoGpt4Mini.go
+++ b/providers/duckduckgo/duckduckgoGpt4Mini.go
@@ -1,0 +1,140 @@
+package duckduckgo
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	http "github.com/bogdanfinn/fhttp"
+
+	"github.com/aandrew-me/tgpt/v2/client"
+	"github.com/aandrew-me/tgpt/v2/structs"
+)
+
+type Message struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type RequestData struct {
+	Model    string    `json:"model"`
+	Messages []Message `json:"messages"`
+}
+
+func NewRequest(input string, params structs.Params, prevMessages string) (*http.Response, error) {
+	client, err := client.NewClient()
+	if err != nil {
+		return nil, fmt.Errorf("error creating client: %v", err)
+	}
+
+	headers := map[string]string{
+		"User-Agent":      "Mozilla/5.0 (X11; Linux x86_64; rv:127.0) Gecko/20100101 Firefox/127.0",
+		"Accept":          "text/event-stream",
+		"Accept-Language": "en-US;q=0.7,en;q=0.3",
+		"Accept-Encoding": "gzip, deflate, br",
+		"Referer":         "https://duckduckgo.com/",
+		"Content-Type":    "application/json",
+		"Origin":          "https://duckduckgo.com",
+		"Connection":      "keep-alive",
+		"Cookie":          "dcm=1",
+		"Sec-Fetch-Dest":  "empty",
+		"Sec-Fetch-Mode":  "cors",
+		"Sec-Fetch-Site":  "same-origin",
+		"Pragma":          "no-cache",
+		"TE":              "trailers",
+		"x-vqd-accept":    "1",
+		"Cache-Control":   "no-store",
+	}
+
+	statusReq, err := http.NewRequest("GET", "https://duckduckgo.com/duckchat/v1/status", nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating status request: %v", err)
+	}
+
+	for key, value := range headers {
+		statusReq.Header.Set(key, value)
+	}
+
+	statusResp, err := client.Do(statusReq)
+	if err != nil {
+		return nil, fmt.Errorf("error making status request: %v", err)
+	}
+	defer statusResp.Body.Close()
+
+	token := statusResp.Header.Get("x-vqd-4")
+	headers["x-vqd-4"] = token
+
+	model := "gpt-4o-mini"
+	if params.ApiModel != "" {
+		model = params.ApiModel
+	}
+
+	var messageHistory []Message
+	if prevMessages != "" {
+		err = json.Unmarshal([]byte(prevMessages), &messageHistory)
+		if err != nil {
+			return nil, fmt.Errorf("error unmarshalling prevMessages: %v", err)
+		}
+	}
+
+	messageHistory = append(messageHistory, Message{
+		Role:    "user",
+		Content: input,
+	})
+
+	data := RequestData{
+		Model:    model,
+		Messages: messageHistory,
+	}
+
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling request data: %v", err)
+	}
+
+	req, err := http.NewRequest("POST", "https://duckduckgo.com/duckchat/v1/chat", strings.NewReader(string(jsonData)))
+	if err != nil {
+		return nil, fmt.Errorf("error creating chat request: %v", err)
+	}
+
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error making chat request: %v", err)
+	}
+
+	return resp, nil
+}
+
+func GetMainText(line string) (mainText string) {
+	if len(line) > 6 && line[6] == '{' {
+		var dat map[string]interface{}
+		if err := json.Unmarshal([]byte(line[6:]), &dat); err == nil {
+			if message, ok := dat["message"].(string); ok {
+				return strings.ReplaceAll(message, "\\n", "\n")
+			}
+		}
+	}
+	return ""
+}
+
+func HandleResponse(resp *http.Response) error {
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "data: ") {
+			mainText := GetMainText(line)
+			if mainText != "" {
+				fmt.Print(mainText)
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("error reading response: %v", err)
+	}
+	return nil
+}

--- a/providers/opengpts/opengpts.go
+++ b/providers/opengpts/opengpts.go
@@ -74,7 +74,7 @@ func NewRequest(input string, params structs.Params, extraOptions structs.ExtraO
 	req.Header.Add("referer", "https://opengpts-example-vz4y4ooboq-uc.a.run.app/")
 	req.Header.Add("sec-fetch-site", "same-origin")
 	req.Header.Add("sec-gpc", "1")
-	req.Header.Add("user-agent", "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
+	req.Header.Add("user-agent", "Mozilla/5.0 (X11; Linux x86_64; rv:127.0) Gecko/20100101 Firefox/127.0")
 
 	// Return response
 	return (client.Do(req))

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/aandrew-me/tgpt/v2/providers/blackboxai"
+	"github.com/aandrew-me/tgpt/v2/providers/duckduckgo"
 	"github.com/aandrew-me/tgpt/v2/providers/groq"
 	"github.com/aandrew-me/tgpt/v2/providers/koboldai"
 	"github.com/aandrew-me/tgpt/v2/providers/ollama"
@@ -16,7 +17,7 @@ import (
 )
 
 var availableProviders = []string{
-	"", "opengpts", "ollama", "openai", "phind", "koboldai", "blackboxai", "groq",
+	"", "opengpts", "ollama", "openai", "phind", "koboldai", "blackboxai", "groq", "duckduckgo",
 }
 
 func GetMainText(line string, provider string, input string) string {
@@ -24,6 +25,8 @@ func GetMainText(line string, provider string, input string) string {
 		return blackboxai.GetMainText(line)
 	} else if provider == "groq" {
 		return groq.GetMainText(line)
+	} else if provider == "duckduckgo" {
+		return duckduckgo.GetMainText(line)
 	} else if provider == "koboldai" {
 		return koboldai.GetMainText(line)
 	} else if provider == "ollama" {
@@ -56,8 +59,10 @@ func NewRequest(input string, params structs.Params, extraOptions structs.ExtraO
 		return blackboxai.NewRequest(input, params, extraOptions.PrevMessages)
 	} else if params.Provider == "groq" {
 		return groq.NewRequest(input, params, extraOptions.PrevMessages)
+	} else if params.Provider == "duckduckgo" {
+		return duckduckgo.NewRequest(input, params, extraOptions.PrevMessages)
 	} else if params.Provider == "koboldai" {
-		return koboldai.NewRequest(input, params, "")
+		return koboldai.NewRequest(input, params, extraOptions.PrevMessages)
 	} else if params.Provider == "ollama" {
 		return ollama.NewRequest(input, params, extraOptions.PrevMessages)
 	} else if params.Provider == "opengpts" {


### PR DESCRIPTION
Changes:
 - Added GPT-4-mini, from duckduckgo\'s endpoint. Changed default user-agent to "Linux" too (we gotta contribute to making `linux`'s marketshare be bigger in the pie charts!)
 
Screenshot:
![image](https://github.com/user-attachments/assets/98607a4e-d156-4743-8831-808cc76c1903)

Note: Duckduckgo currently hosts a lot of interesting and novel AI models, such as Claude's Haiku, LLaMA 70b, and etc, I would love to see those here. Also, unrelated; Would you be open to doing a major refactor of `tgpt` to avoid code repetition? And creating/using ./pkg/ccmd (which would be very similar to [a-utils/pkg/ccmd](https://github.com/xplshn/a-utils/blob/master/pkg/ccmd/ccmd.go))?.

I'd like to contribute to making `tgpt` smaller, readable and more useful, also, have you considered replacing bubbletea? Its a heavy dependency, and it isn't really justified for what is used here...