### PR TITLE
feat(README.md): 📄 add disable-input-limit option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Options:
 -m, --multiline                                    Start multi-line interactive mode 
 -cl, --changelog                                   See changelog of versions 
 -u, --update                                       Update program 
+--disable-input-limit                              Disables the checking of 4000 character input limit
 
 Providers:
 The default provider is phind. The AI_PROVIDER environment variable can be used to specify a different provider.


### PR DESCRIPTION
The option for disabling input limit as part of [v2.8.1](https://github.com/aandrew-me/tgpt/releases/tag/v2.8.1) release but the docs does not mention about it.

Adding the option details in the docs for visibility.