### PR TITLE
Fix #350 Missing letter in response

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -340,16 +340,13 @@ func handleEachPart(resp *http.Response, input string) string {
 	size, termwidthErr := ts.GetSize()
 	termWidth := size.Col()
 
-	previousText := ""
 	fullText := ""
 
 	for scanner.Scan() {
-		newText := providers.GetMainText(scanner.Text(), *provider, input)
-		if len(newText) < 1 {
+		mainText := providers.GetMainText(scanner.Text(), *provider, input)
+		if len(mainText) < 1 {
 			continue
 		}
-		mainText := strings.Replace(newText, previousText, "", -1)
-		previousText = newText
 		fullText += mainText
 
 		if count <= 0 {
@@ -816,16 +813,13 @@ func makeRequestAndGetData(input string, params structs.Params, extraOptions str
 	scanner := bufio.NewScanner(resp.Body)
 
 	// Handling each part
-	previousText := ""
 	fullText := ""
 
 	for scanner.Scan() {
-		newText := providers.GetMainText(scanner.Text(), *provider, input)
-		if len(newText) < 1 {
+		mainText := providers.GetMainText(scanner.Text(), *provider, input)
+		if len(mainText) < 1 {
 			continue
 		}
-		mainText := strings.Replace(newText, previousText, "", -1)
-		previousText = newText
 		fullText += mainText
 
 		if !extraOptions.IsGetWhole {


### PR DESCRIPTION
This issue #350  occurs in the following scenario:
```
prevText := "i"
newText := " input"

mainText := strings.Replace(" input", "i", "", -1)  # Results in " nput"
```


I have tested it with Phind and Gemini, it's working fine.

## Test
Before commit and after commit.
![image](https://github.com/user-attachments/assets/7e3da8e9-382d-4b0f-964d-c669af6bdfdd)
