### PR TITLE
Add interactive shell mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Options:
 -h, --help                                         Print help message
 -i, --interactive                                  Start normal interactive mode
 -m, --multiline                                    Start multi-line interactive mode
+-is, --interactive-shell                           Start interactive shell mode
 -cl, --changelog                                   See changelog of versions
 
 Providers:

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"regexp"
 	"runtime"
 	"strings"
 	"syscall"
@@ -78,7 +79,6 @@ func main() {
 	imgNegative = flag.String("img_negative", "", "Negative prompt. Avoid generating specific elements or characteristics")
 	imgCount = flag.String("img_count", "1", "Number of images you want to generate")
 	imgRatio = flag.String("img_ratio", "1:1", "Image Aspect Ratio")
-	
 
 	defaultUrl := ""
 
@@ -86,7 +86,7 @@ func main() {
 		// ideally default value should be inside openai provider file. To retain existing behavior and avoid braking change default value for openai is set here.
 		defaultUrl = "https://api.openai.com/v1/chat/completions"
 	}
-	
+
 	url = flag.String("url", defaultUrl, "url for openai providers")
 
 	logFile = flag.String("log", "", "Filepath to log conversation to.")
@@ -113,6 +113,9 @@ func main() {
 	isMultiline := flag.Bool("m", false, "Start multi-line interactive mode")
 	flag.BoolVar(isMultiline, "multiline", false, "Start multi-line interactive mode")
 
+	isInteractiveShell := flag.Bool("is", false, "Start shell interactive mode")
+	flag.BoolVar(isInteractiveShell, "interactive-shell", false, "Start shell interactive mode")
+
 	isVersion := flag.Bool("v", false, "Gives response back as a whole text")
 	flag.BoolVar(isVersion, "version", false, "Gives response back as a whole text")
 
@@ -128,28 +131,27 @@ func main() {
 	flag.Parse()
 
 	main_params := structs.Params{
-		ApiKey: *apiKey,
-		ApiModel: *apiModel,
-		Provider: *provider,
-		Temperature: *temperature,
-		Top_p: *top_p,
-		Max_length: *max_length,
-		Preprompt: *preprompt,
-		ThreadID: "",
-		Url: *url,
+		ApiKey:       *apiKey,
+		ApiModel:     *apiModel,
+		Provider:     *provider,
+		Temperature:  *temperature,
+		Top_p:        *top_p,
+		Max_length:   *max_length,
+		Preprompt:    *preprompt,
+		ThreadID:     "",
+		Url:          *url,
 		PrevMessages: "",
 	}
 
-	image_params := structs.ImageParams {
-		ImgRatio: *imgRatio,
+	image_params := structs.ImageParams{
+		ImgRatio:          *imgRatio,
 		ImgNegativePrompt: *imgNegative,
-		ImgCount: *imgCount,
-		Width: *width,
-		Height: *height,
-		Out: *out,
-		Params: main_params,
+		ImgCount:          *imgCount,
+		Width:             *width,
+		Height:            *height,
+		Out:               *out,
+		Params:            main_params,
 	}
-
 
 	prompt := flag.Arg(0)
 
@@ -158,10 +160,10 @@ func main() {
 	contextText := ""
 
 	stat, err := os.Stdin.Stat()
-	
+
 	if err != nil {
 		utils.PrintError(fmt.Sprintf("Error accessing standard input: %v", err))
-		
+
 		return
 	}
 
@@ -174,7 +176,7 @@ func main() {
 
 		if err := scanner.Err(); err != nil {
 			utils.PrintError(fmt.Sprintf("Error reading standard input: %v", err))
-			
+
 			return
 		}
 	}
@@ -213,14 +215,13 @@ func main() {
 		case *isChangelog:
 			helper.GetVersionHistory()
 		case *isImage:
-			
 
 			if len(prompt) > 1 {
 				trimmedPrompt := strings.TrimSpace(prompt)
 				if len(trimmedPrompt) < 1 {
 					utils.PrintError("You need to provide some text")
 					utils.PrintError(`Example: tgpt -img "cat"`)
-					
+
 					return
 				}
 
@@ -240,7 +241,7 @@ func main() {
 				if len(trimmedPrompt) < 1 {
 					utils.PrintError("You need to provide some text")
 					utils.PrintError(`Example: tgpt -w "What is encryption?"`)
-					
+
 					return
 				}
 				helper.GetWholeText(
@@ -262,14 +263,14 @@ func main() {
 				if len(trimmedPrompt) < 1 {
 					utils.PrintError("You need to provide some text")
 					utils.PrintError(`Example: tgpt -q "What is encryption?"`)
-					
+
 					return
 				}
 				helper.MakeRequestAndGetData(*preprompt+trimmedPrompt+contextText+pipedInput, main_params, structs.ExtraOptions{IsGetSilent: true})
 			} else {
 				formattedInput := bubbletea.GetFormattedInputStdin()
 				fmt.Println()
-				helper.MakeRequestAndGetData(*preprompt+formattedInput+cleanPipedInput, main_params, structs.ExtraOptions{IsGetSilent: true},)
+				helper.MakeRequestAndGetData(*preprompt+formattedInput+cleanPipedInput, main_params, structs.ExtraOptions{IsGetSilent: true})
 			}
 		case *isShell:
 			if len(prompt) > 1 {
@@ -277,21 +278,21 @@ func main() {
 				if len(trimmedPrompt) < 1 {
 					utils.PrintError("You need to provide some text")
 					utils.PrintError(`Example: tgpt -s "How to update system"`)
-					
+
 					return
 				}
 				helper.ShellCommand(
-					*preprompt + trimmedPrompt + contextText + pipedInput,
+					*preprompt+trimmedPrompt+contextText+pipedInput,
 					main_params,
 					structs.ExtraOptions{
 						IsGetCommand: true,
-						AutoExec: *shouldExecuteCommand,
+						AutoExec:     *shouldExecuteCommand,
 					},
 				)
 			} else {
 				utils.PrintError("You need to provide some text")
 				utils.PrintError(`Example: tgpt -s "How to update system"`)
-				
+
 				return
 			}
 
@@ -304,13 +305,13 @@ func main() {
 					os.Exit(1)
 				}
 				helper.CodeGenerate(
-					*preprompt + trimmedPrompt + contextText + pipedInput,
+					*preprompt+trimmedPrompt+contextText+pipedInput,
 					main_params,
 				)
 			} else {
 				utils.PrintError("You need to provide some text")
 				utils.PrintError(`Example: tgpt -c "Hello world in Python"`)
-				
+
 				return
 			}
 		case *isUpdate:
@@ -402,7 +403,7 @@ func main() {
 
 				if err != nil {
 					utils.PrintError(err.Error())
-					
+
 					os.Exit(1)
 				}
 				if len(userInput) > 0 {
@@ -424,6 +425,114 @@ func main() {
 
 			}
 
+		case *isInteractiveShell:
+			/////////////////////
+			// shell interactive
+			/////////////////////
+
+			bold.Print("Interactive Shell mode started. Press Ctrl + C or type exit to quit.\n\n")
+			helper.SetShellAndOSVars()
+			promptIs := fmt.Sprintf("You are a powerful terminal assistant. Answer the needs of the user."+
+				"You can execute command in command line if need. Always wrap the command with the xml tag `<tgpt_command>`."+
+				"Only output command when you think user wants to execute a command. Execute only one command in one response."+
+				"The shell environment you are is %s. The operate system you are is %s."+
+				"Examples:"+
+				"User: list the files in my home dir."+
+				"Assistant: Sure. I will list the files under your home dir. <tgpt_command>ls ~</tgpt_command>",
+				helper.ShellName, helper.OperatingSystem,
+			)
+			previousMessages := ""
+			threadID := utils.RandomString(36)
+			history := []string{}
+
+			getAndPrintResponse := func(input string) string {
+				input = strings.TrimSpace(input)
+				if len(input) <= 1 {
+					return ""
+				}
+				if input == "exit" {
+					bold.Println("Exiting...")
+					if runtime.GOOS != "windows" {
+						rawModeOff := exec.Command("stty", "-raw", "echo")
+						rawModeOff.Stdin = os.Stdin
+						_ = rawModeOff.Run()
+						rawModeOff.Wait()
+					}
+					os.Exit(0)
+				}
+				if len(*logFile) > 0 {
+					utils.LogToFile(input, "USER_QUERY", *logFile)
+				}
+				// Use preprompt for first message
+				if previousMessages == "" {
+					input = *preprompt + input
+				}
+
+				main_params.PrevMessages = previousMessages
+				main_params.ThreadID = threadID
+				main_params.SystemPrompt = promptIs
+
+				responseJson, responseTxt := helper.GetData(input, main_params, structs.ExtraOptions{IsInteractiveShell: true, IsNormal: true})
+				// Regex to match complete <tgpt_command>...</tgpt_command>
+				commandRegex := regexp.MustCompile(`<tgpt_command>(.*?)</tgpt_command>`)
+				matches := commandRegex.FindStringSubmatch(responseTxt)
+				if len(matches) > 1 {
+					command := strings.TrimSpace(matches[1])
+					// execute command
+					return command
+				}
+				if len(*logFile) > 0 {
+					utils.LogToFile(responseTxt, "ASSISTANT_RESPONSE", *logFile)
+				}
+				previousMessages += responseJson
+				history = append(history, input)
+				lastResponse = responseTxt
+				return ""
+			}
+
+			input := strings.TrimSpace(prompt)
+			if len(input) > 1 {
+				// if prompt is passed in interactive mode then send prompt as first message
+				blue.Println("╭─ You")
+				blue.Print("╰─> ")
+				fmt.Println(input)
+				getAndPrintResponse(input)
+			}
+
+			for {
+				blue.Println("╭─ You")
+				input := Prompt.Input("╰─> ", bubbletea.HistoryCompleter,
+					Prompt.OptionHistory(history),
+					Prompt.OptionPrefixTextColor(Prompt.Blue),
+					Prompt.OptionAddKeyBind(Prompt.KeyBind{
+						Key: Prompt.ControlC,
+						Fn:  exit,
+					}),
+				)
+				cmd := getAndPrintResponse(input)
+				if cmd != "" {
+					if *shouldExecuteCommand {
+						fmt.Println()
+						helper.ExecuteCommand(helper.ShellName, helper.ShellOptions, cmd)
+					} else {
+						bold.Printf("\n\nExecute shell command: `%s` ? [y/n]: ", cmd)
+						userInput := Prompt.Input("", bubbletea.HistoryCompleter,
+							Prompt.OptionPrefixTextColor(Prompt.Blue),
+							Prompt.OptionAddKeyBind(Prompt.KeyBind{
+								Key: Prompt.ControlC,
+								Fn:  exit,
+							}),
+						)
+						userInput = strings.TrimSpace(userInput)
+
+						if userInput == "y" || userInput == "" {
+							helper.ExecuteCommand(helper.ShellName, helper.ShellOptions, cmd)
+						}
+					}
+				}
+
+			}
+
 		case *isHelp:
 			helper.ShowHelpMessage()
 		default:
@@ -431,7 +540,7 @@ func main() {
 
 			if len(formattedInput) <= 1 {
 				utils.PrintError("You need to write something")
-				
+
 				return
 			}
 
@@ -451,7 +560,6 @@ func main() {
 		helper.GetData(*preprompt+formattedInput+pipedInput, main_params, structs.ExtraOptions{IsInteractive: false})
 	}
 }
-
 
 func exit(_ *Prompt.Buffer) {
 	bold.Println("Exiting...")

--- a/src/helper/helper.go
+++ b/src/helper/helper.go
@@ -37,9 +37,9 @@ type ImgResponse struct {
 }
 
 var (
-	operatingSystem string
-	shellName       string
-	shellOptions    []string
+	OperatingSystem string
+	ShellName       string
+	ShellOptions    []string
 )
 
 var bold = color.New(color.Bold)
@@ -186,47 +186,47 @@ func SetShellAndOSVars() {
 	// Identify OS
 	switch runtime.GOOS {
 	case "windows":
-		operatingSystem = "Windows"
+		OperatingSystem = "Windows"
 		if len(os.Getenv("PSModulePath")) > 0 {
-			shellName = "powershell.exe"
-			shellOptions = []string{"-Command"}
+			ShellName = "powershell.exe"
+			ShellOptions = []string{"-Command"}
 		} else {
-			shellName = "cmd.exe"
-			shellOptions = []string{"/C"}
+			ShellName = "cmd.exe"
+			ShellOptions = []string{"/C"}
 		}
 		return
 	case "darwin":
-		operatingSystem = "MacOS"
+		OperatingSystem = "MacOS"
 	case "linux":
 		result, err := exec.Command("lsb_release", "-si").Output()
 		distro := strings.TrimSpace(string(result))
 		if err != nil {
 			distro = ""
 		}
-		operatingSystem = "Linux" + "/" + distro
+		OperatingSystem = "Linux" + "/" + distro
 	default:
-		operatingSystem = runtime.GOOS
+		OperatingSystem = runtime.GOOS
 	}
 
 	// Identify shell
 	shellEnv := os.Getenv("SHELL")
 	if shellEnv != "" {
-		shellName = shellEnv
+		ShellName = shellEnv
 	} else {
 		_, err := exec.LookPath("bash")
 		if err != nil {
-			shellName = "/bin/sh"
+			ShellName = "/bin/sh"
 		} else {
-			shellName = "bash"
+			ShellName = "bash"
 		}
 	}
-	shellOptions = []string{"-c"}
+	ShellOptions = []string{"-c"}
 }
 
 // shellCommand first sets the global variables getCommand uses, then it creates a prompt to generate a command and then it passes that to getCommand
 func ShellCommand(input string, params structs.Params, extraOptions structs.ExtraOptions) {
 	SetShellAndOSVars()
-	shellPrompt := fmt.Sprintf("Your role: Provide only plain text without Markdown formatting. Do not show any warnings or information regarding your capabilities. Do not provide any description. If you need to store any data, assume it will be stored in the chat. Provide only %s command for %s without any description. If there is a lack of details, provide most logical solution. Ensure the output is a valid shell command. If multiple steps required try to combine them together. Prompt: %s\n\nCommand:", shellName, operatingSystem, input)
+	shellPrompt := fmt.Sprintf("Your role: Provide only plain text without Markdown formatting. Do not show any warnings or information regarding your capabilities. Do not provide any description. If you need to store any data, assume it will be stored in the chat. Provide only %s command for %s without any description. If there is a lack of details, provide most logical solution. Ensure the output is a valid shell command. If multiple steps required try to combine them together. Prompt: %s\n\nCommand:", ShellName, OperatingSystem, input)
 	GetCommand(shellPrompt, params, extraOptions)
 }
 
@@ -456,6 +456,167 @@ func HandleEachPart(resp *http.Response, input string, params structs.Params) st
 
 }
 
+// handle response for interactive shell mode
+func HandleEachPartInteractiveShell(resp *http.Response, input string, params structs.Params) string {
+	scanner := bufio.NewScanner(resp.Body)
+
+	// Variables for formatting
+	count := 0
+	isCode := false
+	isGreen := false
+	tickCount := 0
+	previousWasTick := false
+	isTick := false
+	isRealCode := false
+
+	lineLength := 0
+	size, termwidthErr := ts.GetSize()
+	termWidth := size.Col()
+
+	fullText := ""
+	// Buffer for incomplete XML tags
+	var xmlBuffer strings.Builder
+	// Track if inside XML tag
+	inXMLTag := false
+
+	for scanner.Scan() {
+		mainText := providers.GetMainText(scanner.Text(), params.Provider, input)
+		if len(mainText) < 1 {
+			continue
+		}
+
+		// Process stream, separating XML tags from natural language/code blocks
+		for _, char := range mainText {
+			word := string(char)
+			fullText += word
+			if char == '<' && !inXMLTag {
+				// Start new XML tag
+				inXMLTag = true
+				xmlBuffer.WriteRune(char)
+			} else if char == '>' && inXMLTag {
+				// Possibly end tag part
+				xmlBuffer.WriteRune(char)
+				currentBuffer := xmlBuffer.String()
+				if strings.HasPrefix(currentBuffer, "<tgpt_command>") && strings.HasSuffix(currentBuffer, "</tgpt_command>") {
+					xmlBuffer.Reset()
+					inXMLTag = false
+				}
+			} else if inXMLTag {
+				// Inside XML tag, continue buffering
+				xmlBuffer.WriteRune(char)
+			} else {
+				// Original formatting logic
+				if count <= 0 {
+					wordLength := len([]rune(word))
+					if termwidthErr == nil && (termWidth-lineLength < wordLength) && params.Provider != "gemini" {
+						fmt.Print("\n")
+						lineLength = 0
+					}
+					lineLength += wordLength
+
+					// Handle code blocks and colors
+					if word == "`" {
+						tickCount++
+						isTick = true
+						if tickCount == 2 && !previousWasTick {
+							tickCount = 0
+						} else if tickCount == 6 {
+							tickCount = 0
+						}
+						previousWasTick = true
+						isGreen = false
+						isCode = false
+					} else {
+						isTick = false
+						switch tickCount {
+						case 1:
+							isGreen = true
+						case 3:
+							isCode = true
+						}
+						previousWasTick = false
+					}
+
+					if isCode {
+						codeText.Print(word)
+					} else if isGreen {
+						boldBlue.Print(word)
+					} else if !isTick {
+						fmt.Print(word)
+					}
+				} else {
+					wordLength := len([]rune(word))
+					if termwidthErr == nil && (termWidth-lineLength < wordLength) && params.Provider != "gemini" {
+						fmt.Print("\n")
+						lineLength = 0
+					}
+					lineLength += wordLength
+
+					if mainText == "``" || mainText == "```" {
+						isRealCode = true
+					} else {
+						isRealCode = false
+					}
+
+					// Handle code blocks and colors
+					if word == "`" {
+						tickCount++
+						isTick = true
+						if tickCount == 2 && !previousWasTick {
+							tickCount = 0
+						} else if tickCount >= 6 && tickCount%2 == 0 && previousWasTick {
+							tickCount = 0
+						}
+						isGreen = false
+						isCode = false
+					} else {
+						if word == "\n" {
+							lineLength = 0
+						}
+						isTick = false
+						if tickCount == 1 {
+							isGreen = true
+						} else if tickCount >= 3 {
+							isCode = true
+						}
+					}
+
+					if isCode {
+						codeText.Print(word)
+					} else if isGreen {
+						boldBlue.Print(word)
+					} else if !isTick {
+						fmt.Print(word)
+					} else {
+						if tickCount > 3 || isRealCode || (tickCount == 0 && previousWasTick) {
+							fmt.Print(word)
+						}
+					}
+
+					if word == "`" {
+						previousWasTick = true
+					} else {
+						previousWasTick = false
+					}
+				}
+			}
+		}
+		count++
+	}
+
+	// Check for unprocessed XML tag remnants
+	if inXMLTag && xmlBuffer.Len() > 0 {
+		fmt.Fprintf(os.Stderr, "Warning: Incomplete XML tag: %s\n", xmlBuffer.String())
+	}
+
+	if err := scanner.Err(); err != nil {
+		fmt.Fprintln(os.Stderr, "Error occurred:", err)
+		os.Exit(1)
+	}
+
+	return fullText
+}
+
 func printConnectionErrorMsg(err error) {
 	bold.Fprintln(os.Stderr, "\rSome error has occurred. Check your internet connection.")
 	fmt.Fprintln(os.Stderr, "\nError:", err)
@@ -570,7 +731,7 @@ func AddToShellHistory(command string) {
 func MakeRequestAndGetData(input string, params structs.Params, extraOptions structs.ExtraOptions) string {
 	stopSpin := false
 
-	if !extraOptions.IsGetSilent && !extraOptions.IsGetWhole && !extraOptions.IsInteractive {
+	if !extraOptions.IsGetSilent && !extraOptions.IsGetWhole && !extraOptions.IsInteractive && !extraOptions.IsInteractiveShell {
 		go Loading(&stopSpin)
 	}
 
@@ -602,7 +763,7 @@ func MakeRequestAndGetData(input string, params structs.Params, extraOptions str
 
 	if extraOptions.IsNormal {
 		// Print the Question
-		if !extraOptions.IsInteractive {
+		if !extraOptions.IsInteractive && !extraOptions.IsInteractiveShell {
 			fmt.Print("\r          \r")
 			// bold.Printf("\r%v\n\n", input)
 			bold.Println()
@@ -612,6 +773,9 @@ func MakeRequestAndGetData(input string, params structs.Params, extraOptions str
 		}
 
 		// Handling each part
+		if extraOptions.IsInteractiveShell {
+			return HandleEachPartInteractiveShell(resp, input, params)
+		}
 		return HandleEachPart(resp, input, params)
 	}
 
@@ -655,7 +819,7 @@ func MakeRequestAndGetData(input string, params structs.Params, extraOptions str
 		if lineCount == 1 {
 			if extraOptions.AutoExec {
 				fmt.Println()
-				ExecuteCommand(shellName, shellOptions, fullText)
+				ExecuteCommand(ShellName, ShellOptions, fullText)
 			} else {
 				bold.Print("\n\nExecute shell command? [y/n]: ")
 				reader := bufio.NewReader(os.Stdin)
@@ -663,7 +827,7 @@ func MakeRequestAndGetData(input string, params structs.Params, extraOptions str
 				userInput = strings.TrimSpace(userInput)
 
 				if userInput == "y" || userInput == "" {
-					ExecuteCommand(shellName, shellOptions, fullText)
+					ExecuteCommand(ShellName, ShellOptions, fullText)
 				}
 			}
 		}
@@ -707,6 +871,7 @@ func ShowHelpMessage() {
 	fmt.Printf("%-50v Print help message \n", "-h, --help")
 	fmt.Printf("%-50v Start normal interactive mode \n", "-i, --interactive")
 	fmt.Printf("%-50v Start multi-line interactive mode \n", "-m, --multiline")
+	fmt.Printf("%-50v Start interactive shell mode \n", "-is, --interactive-shell")
 	fmt.Printf("%-50v See changelog of versions \n", "-cl, --changelog")
 
 	if runtime.GOOS != "windows" {

--- a/src/imagegen/imagegen.go
+++ b/src/imagegen/imagegen.go
@@ -46,6 +46,7 @@ func GenerateImg(prompt string, params structs.ImageParams, isQuite bool) {
 
 func generateImagePollinations(prompt string, params structs.ImageParams) string {
 	client, err := client.NewClient()
+	
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
@@ -70,14 +71,26 @@ func generateImagePollinations(prompt string, params structs.ImageParams) string
 
 	seed := utils.GenerateRandomNumber(5)
 
+	width := strconv.Itoa(params.Width)
+	if (width == "") {
+		width = "1024"
+	}
+
+	height := strconv.Itoa(params.Height)
+	if (height == "") {
+		height = "1024"
+	}
+
+	fmt.Println(width)
+
 	queryParams.Add("model", model)
-	queryParams.Add("width", strconv.Itoa(params.Width))
-	queryParams.Add("height", strconv.Itoa(params.Height))
+	queryParams.Add("width", width)
+	queryParams.Add("height", height)
 	queryParams.Add("nologo", "true")
-	queryParams.Add("safe", "false")
-	queryParams.Add("nsfw", "true")
-	queryParams.Add("isChild", "false")
 	queryParams.Add("seed", seed)
+	queryParams.Add("private", "true")
+	queryParams.Add("enhance", "true")
+
 
 	urlObj, err := url_package.Parse(link)
 	if err != nil {
@@ -88,6 +101,8 @@ func generateImagePollinations(prompt string, params structs.ImageParams) string
 	urlObj.RawQuery = queryParams.Encode()
 
 	req, _ := http.NewRequest("GET", urlObj.String(), nil)
+
+	req.Header.Add("Referrer", "tgpt")
 
 	res, err := client.Do(req)
 

--- a/src/providers/blackboxai/blackboxai.go
+++ b/src/providers/blackboxai/blackboxai.go
@@ -24,6 +24,10 @@ func NewRequest(input string, params structs.Params) (*http.Response, error) {
 	var data = strings.NewReader(fmt.Sprintf(`
 	{
 		"messages": [
+			{
+				"content": "%s",
+				"role": "system"
+			},
 			%v
 			{
 				"content": %v,
@@ -33,7 +37,7 @@ func NewRequest(input string, params structs.Params) (*http.Response, error) {
 		"model": "deepseek-ai/DeepSeek-R1",
 		"max_tokens": "10000"
 	}
-	`, params.PrevMessages, string(safeInput)))
+	`, params.SystemPrompt, params.PrevMessages, string(safeInput)))
 
 	req, err := http.NewRequest("POST", "https://api.blackbox.ai/api/chat", data)
 	if err != nil {

--- a/src/providers/deepseek/deepseek.go
+++ b/src/providers/deepseek/deepseek.go
@@ -45,6 +45,10 @@ func NewRequest(input string, params structs.Params) (*http.Response, error) {
 
 	var data = strings.NewReader(fmt.Sprintf(`{
 		"messages": [
+			{
+				"content": "%s",
+				"role": "system"
+			},
 			%v
 			{
 				"content": %v,
@@ -56,7 +60,7 @@ func NewRequest(input string, params structs.Params) (*http.Response, error) {
 		"temperature": %v,
 		"top_p": %v
 	}
-	`, params.PrevMessages, string(safeInput), model, temperature, top_p))
+	`, params.SystemPrompt, params.PrevMessages, string(safeInput), model, temperature, top_p))
 
 	req, err := http.NewRequest("POST", "https://api.deepseek.com/chat/completions", data)
 	if err != nil {

--- a/src/providers/duckduckgo/duckduckgo.go
+++ b/src/providers/duckduckgo/duckduckgo.go
@@ -96,6 +96,10 @@ func NewRequest(input string, params structs.Params, prevMessages string) (*http
 
 	var data = strings.NewReader(fmt.Sprintf(`{
 		"messages": [
+			{
+				"content": "%s",
+				"role": "system"
+			},
 			%v
 			{
 				"content": %v,
@@ -104,7 +108,7 @@ func NewRequest(input string, params structs.Params, prevMessages string) (*http
 		],
 		"model": "%v"
 	}
-	`, params.PrevMessages, string(safeInput), model))
+	`, params.SystemPrompt, params.PrevMessages, string(safeInput), model))
 
 	req, err := http.NewRequest("POST", "https://duckduckgo.com/duckchat/v1/chat", data)
 	if err != nil {

--- a/src/providers/gemini/gemini.go
+++ b/src/providers/gemini/gemini.go
@@ -34,13 +34,18 @@ func NewRequest(input string, params structs.Params) (*http.Response, error) {
 	safeInput, _ := json.Marshal(input)
 
 	dataStr := fmt.Sprintf(`{
+		"systemInstruction": {
+			"parts":[{
+				"text": "%s"
+			}]
+		},
 		"contents": [
 		  %v
 		  { 
 			"role": "user",
 			"parts": [ { "text": %v }]
 		  }
-	]}`, params.PrevMessages, string(safeInput))
+	]}`, params.SystemPrompt, params.PrevMessages, string(safeInput))
 
 	data := strings.NewReader(dataStr)
 

--- a/src/providers/groq/groq.go
+++ b/src/providers/groq/groq.go
@@ -39,6 +39,10 @@ func NewRequest(input string, params structs.Params) (*http.Response, error) {
 	var data = strings.NewReader(fmt.Sprintf(`{
 		"frequency_penalty": 0,
 		"messages": [
+			{
+				"content": "%s",
+				"role": "system"
+			},
 			%v
 			{
 				"content": %v,
@@ -51,7 +55,7 @@ func NewRequest(input string, params structs.Params) (*http.Response, error) {
 		"temperature": %v,
 		"top_p": %v
 	}
-	`, params.PrevMessages, string(safeInput), model, temperature, top_p))
+	`, params.SystemPrompt, params.PrevMessages, string(safeInput), model, temperature, top_p))
 
 	req, err := http.NewRequest("POST", "https://api.groq.com/openai/v1/chat/completions", data)
 	if err != nil {

--- a/src/providers/ollama/ollama.go
+++ b/src/providers/ollama/ollama.go
@@ -39,6 +39,10 @@ func NewRequest(input string, params structs.Params) (*http.Response, error) {
 	var data = strings.NewReader(fmt.Sprintf(`{
 		"frequency_penalty": 0,
 		"messages": [
+			{
+				"content": "%s",
+				"role": "system"
+			},
 			%v
 			{
 				"content": %v,
@@ -51,7 +55,7 @@ func NewRequest(input string, params structs.Params) (*http.Response, error) {
 		"temperature": %v,
 		"top_p": %v
 	}
-	`, params.PrevMessages, string(safeInput), model, temperature, top_p))
+	`, params.SystemPrompt, params.PrevMessages, string(safeInput), model, temperature, top_p))
 
 	req, err := http.NewRequest("POST", "http://localhost:11434/v1/chat/completions", data)
 	if err != nil {

--- a/src/providers/openai/openai.go
+++ b/src/providers/openai/openai.go
@@ -53,6 +53,10 @@ func NewRequest(input string, params structs.Params) (*http.Response, error) {
 	baseFormat := `{
 		"frequency_penalty": 0,
 		"messages": [
+			{
+				"content": "%v",
+				"role": "system"
+			},
 			%v
 			{
 				"content": %v,
@@ -74,7 +78,7 @@ func NewRequest(input string, params structs.Params) (*http.Response, error) {
 	`
 
 	// Prepare the arguments for fmt.Sprintf
-	args := []interface{}{params.PrevMessages, string(safeInput), model, temperature}
+	args := []interface{}{params.SystemPrompt, params.PrevMessages, string(safeInput), model, temperature}
 	if includeTopP {
 		args = append(args, top_p)
 	}

--- a/src/providers/phind/phind.go
+++ b/src/providers/phind/phind.go
@@ -44,6 +44,10 @@ func NewRequest(input string, params structs.Params) (*http.Response, error) {
 		"allow_magic_buttons": true,
 		"is_vscode_extension": true,
 		"message_history": [
+			{
+				"content": "%s",
+				"role": "system"
+			},
 			%v
 			{
 				"content": %v,
@@ -53,7 +57,7 @@ func NewRequest(input string, params structs.Params) (*http.Response, error) {
 		"requested_model": "%v",
 		"user_input": %v
 	}
-	`, params.PrevMessages, string(safeInput), model, string(safeInput)))
+	`, params.SystemPrompt, params.PrevMessages, string(safeInput), model, string(safeInput)))
 
 	req, err := http.NewRequest("POST", "https://https.extension.phind.com/agent/", data)
 	if err != nil {

--- a/src/providers/pollinations/pollinations.go
+++ b/src/providers/pollinations/pollinations.go
@@ -38,6 +38,10 @@ func NewRequest(input string, params structs.Params) (*http.Response, error) {
 
 	var data = strings.NewReader(fmt.Sprintf(`{
 		"messages": [
+			{
+				"content": "%s",
+				"role": "system"
+			},
 			%v
 			{
 				"content": %v,
@@ -49,7 +53,7 @@ func NewRequest(input string, params structs.Params) (*http.Response, error) {
 		"temperature": %v,
 		"top_p": %v
 	}
-	`, params.PrevMessages, string(safeInput), model, temperature, top_p))
+	`, params.SystemPrompt, params.PrevMessages, string(safeInput), model, temperature, top_p))
 
 	req, err := http.NewRequest("POST", "https://text.pollinations.ai/openai", data)
 	if err != nil {

--- a/src/structs/structs.go
+++ b/src/structs/structs.go
@@ -11,16 +11,18 @@ type Params struct {
 	ThreadID     string
 	Url          string
 	PrevMessages string
+	SystemPrompt string
 }
 
 type ExtraOptions struct {
-	IsGetSilent       bool
-	IsGetWhole        bool
-	IsGetCommand      bool
-	IsNormal          bool
-	IsGetCode         bool
-	IsInteractive     bool
-	AutoExec		  bool
+	IsGetSilent        bool
+	IsGetWhole         bool
+	IsGetCommand       bool
+	IsNormal           bool
+	IsGetCode          bool
+	IsInteractive      bool
+	IsInteractiveShell bool
+	AutoExec           bool
 }
 
 type CommonResponse struct {
@@ -34,10 +36,10 @@ type CommonResponse struct {
 
 type ImageParams struct {
 	Params
-	Height int
-	Width  int
-	Out    string
+	Height            int
+	Width             int
+	Out               string
 	ImgNegativePrompt string
-	ImgRatio string
-	ImgCount string
+	ImgRatio          string
+	ImgCount          string
 }


### PR DESCRIPTION
Created a new mode called interactive shell, which inherits all the features of interactive mode and can execute shell commands. 
Implementation: 
- Use system prompt to force LLM generate commands wrapped in XML `<tgpt_command>` tags. 
- Stream the natural language output except for the commands. Finally, ask whether to execute the command (of course, automatic execution is also supported). 
- If the execution is successful, interaction can continue; if it fails, it will exit (inheriting the characteristics of shell mode).