### PR TITLE
OpenAI o4 support

### DIFF
--- a/src/providers/openai/openai.go
+++ b/src/providers/openai/openai.go
@@ -48,7 +48,14 @@ func NewRequest(input string, params structs.Params) (*http.Response, error) {
 
 	safeInput, _ := json.Marshal(input)
 
-	includeTopP := !strings.HasPrefix(model, "o1")
+	prefixesNoTopP := []string{"o1", "o4"}
+	includeTopP := true
+	for _, prefix := range prefixesNoTopP {
+		if strings.HasPrefix(model, prefix) {
+			includeTopP = false
+			break
+		}
+	}
 
 	baseFormat := `{
 		"frequency_penalty": 0,


### PR DESCRIPTION
Adding o4 prefix to OpenAI models that need `--top_p` option to be absent in order to accept requests.

Otherwise I get the following error : 

```
> export OPENAI_MODEL=o4-mini

> tgpt --temperature=1 "write hello world in go"

Some error has occurred. Statuscode: 400
{
  "error": {
    "message": "Unsupported parameter: 'top_p' is not supported with this model.",
    "type": "invalid_request_error",
    "param": "top_p",
    "code": "unsupported_parameter"
  }
}
```