### PR TITLE
fix: resolve delete key issue in interactive find mode (-if)

### DIFF
--- a/main.go
+++ b/main.go
@@ -599,7 +599,34 @@ func main() {
 				Verbose:           *isVerbose,
 			}
 
-			helper.InteractiveFindSession(main_params, extraOptions, *logFile)
+			// Get the response handler function from helper
+			getAndPrintFindResponse := helper.InteractiveFindSession(main_params, extraOptions, *logFile)
+			history := []string{}
+
+			input := strings.TrimSpace(prompt)
+			if len(input) > 1 {
+				// if prompt is passed in interactive mode then send prompt as first message
+				blue.Println("╭─ You")
+				blue.Print("╰─> ")
+				fmt.Println(input)
+				getAndPrintFindResponse(input)
+			}
+
+			for {
+				blue.Println("╭─ You")
+				input := Prompt.Input("╰─> ", bubbletea.HistoryCompleter,
+					Prompt.OptionHistory(history),
+					Prompt.OptionPrefixTextColor(Prompt.DarkBlue),
+					Prompt.OptionAddKeyBind(Prompt.KeyBind{
+						Key: Prompt.ControlC,
+						Fn:  exit,
+					}),
+				)
+				if len(input) > 0 {
+					getAndPrintFindResponse(input)
+					history = append(history, input)
+				}
+			}
 
 		case *isInteractiveAlias:
 			/////////////////////

--- a/src/helper/helper.go
+++ b/src/helper/helper.go
@@ -976,7 +976,7 @@ func SearchQuery(input string, params structs.Params, extraOptions structs.Extra
 }
 
 // InteractiveFindSession handles the interactive web search conversation mode
-func InteractiveFindSession(params structs.Params, extraOptions structs.ExtraOptions, logFile string) {
+func InteractiveFindSession(params structs.Params, extraOptions structs.ExtraOptions, logFile string) func(string) {
 	var previousMessages []any
 
 	threadID := utils.RandomString(36)
@@ -1074,18 +1074,5 @@ func InteractiveFindSession(params structs.Params, extraOptions structs.ExtraOpt
 		}
 	}
 
-	// Interactive loop using simple input (avoiding import cycles)
-	for {
-		boldBlue.Println("╭─ You")
-		fmt.Print("╰─> ")
-		scanner := bufio.NewScanner(os.Stdin)
-		if !scanner.Scan() {
-			break
-		}
-
-		userInput := scanner.Text()
-		if len(userInput) > 0 {
-			getAndPrintFindResponse(userInput)
-		}
-	}
+	return getAndPrintFindResponse
 }


### PR DESCRIPTION
The delete/backspace key in interactive find mode was displaying '^?' characters instead of actually deleting text. This was caused by using bufio.Scanner for input handling instead of the go-prompt library.

Changes:
- Refactored InteractiveFindSession() to return a response handler function
- Updated main.go to handle interactive input loop using Prompt.Input()
- Added proper keyboard shortcuts and history support
- Maintains consistency with other interactive modes (-i, -is, -ia)