### PR TITLE
Add think flag to show AI reasoning process

### DIFF
--- a/main.go
+++ b/main.go
@@ -131,6 +131,9 @@ func main() {
 	isVerbose := flag.Bool("vb", false, "Enable verbose output for debugging")
 	flag.BoolVar(isVerbose, "verbose", false, "Enable verbose output for debugging")
 
+	isThink := flag.Bool("t", false, "Show thinking process from the AI")
+	flag.BoolVar(isThink, "think", false, "Show thinking process from the AI")
+
 	flag.Parse()
 
 	final_provider := *provider
@@ -258,14 +261,14 @@ func main() {
 				}
 				helper.GetWholeText(
 					*preprompt+trimmedPrompt+contextText+pipedInput,
-					structs.ExtraOptions{IsGetWhole: *isWhole},
+					structs.ExtraOptions{IsGetWhole: *isWhole, IsThink: *isThink},
 					main_params,
 				)
 			} else {
 				formattedInput := bubbletea.GetFormattedInputStdin()
 				helper.GetWholeText(
 					*preprompt+formattedInput+cleanPipedInput,
-					structs.ExtraOptions{IsGetWhole: *isWhole},
+					structs.ExtraOptions{IsGetWhole: *isWhole, IsThink: *isThink},
 					main_params,
 				)
 			}
@@ -285,6 +288,7 @@ func main() {
 						IsGetCommand: true,
 						AutoExec:     *shouldExecuteCommand,
 						IsGetSilent:  *isQuiet,
+						IsThink:      *isThink,
 					},
 				)
 			} else {
@@ -308,6 +312,7 @@ func main() {
 					structs.ExtraOptions{
 						IsGetCode:   true,
 						IsGetSilent: *isQuiet,
+						IsThink:     *isThink,
 					},
 				)
 			} else {
@@ -356,7 +361,7 @@ func main() {
 				main_params.PrevMessages = append(main_params.PrevMessages, previousMessages...)
 				main_params.ThreadID = threadID
 
-				responseObjects, responseTxt := helper.GetData(input, main_params, structs.ExtraOptions{IsInteractive: true, IsNormal: true, IsGetSilent: *isQuiet})
+				responseObjects, responseTxt := helper.GetData(input, main_params, structs.ExtraOptions{IsInteractive: true, IsNormal: true, IsGetSilent: *isQuiet, IsThink: *isThink})
 
 				if len(*logFile) > 0 {
 					utils.LogToFile(responseTxt, "ASSISTANT_RESPONSE", *logFile)
@@ -420,7 +425,7 @@ func main() {
 					main_params.PrevMessages = append(main_params.PrevMessages, previousMessages...)
 					main_params.ThreadID = threadID
 
-					responseObjects, responseTxt := helper.GetData(userInput, main_params, structs.ExtraOptions{IsInteractive: true, IsNormal: true, IsGetSilent: *isQuiet})
+					responseObjects, responseTxt := helper.GetData(userInput, main_params, structs.ExtraOptions{IsInteractive: true, IsNormal: true, IsGetSilent: *isQuiet, IsThink: *isThink})
 					previousMessages = append(previousMessages, responseObjects...)
 					lastResponse = responseTxt
 
@@ -479,7 +484,7 @@ func main() {
 				main_params.ThreadID = threadID
 				main_params.SystemPrompt = promptIs
 
-				responseObjects, responseTxt := helper.GetData(input, main_params, structs.ExtraOptions{IsInteractiveShell: true, IsNormal: true})
+				responseObjects, responseTxt := helper.GetData(input, main_params, structs.ExtraOptions{IsInteractiveShell: true, IsNormal: true, IsThink: *isThink})
 				// Regex to match complete <cmd>...</cmd>
 				commandRegex := regexp.MustCompile(`<cmd>(.*?)</cmd>`)
 				matches := commandRegex.FindStringSubmatch(responseTxt)
@@ -577,6 +582,7 @@ func main() {
 				extraOptions := structs.ExtraOptions{
 					IsFind:  true,
 					Verbose: *isVerbose,
+					IsThink: *isThink,
 				}
 
 				helper.SearchQuery(trimmedPrompt, main_params, extraOptions, *isQuiet, *logFile)
@@ -597,6 +603,7 @@ func main() {
 				IsInteractiveFind: true,
 				IsFind:            true,
 				Verbose:           *isVerbose,
+				IsThink:           *isThink,
 			}
 
 			// Create a prompt-compatible input reader function for confirmations
@@ -688,7 +695,7 @@ func main() {
 				main_params.ThreadID = threadID
 				main_params.SystemPrompt = promptAlias
 
-				responseObjects, responseTxt := helper.GetData(input, main_params, structs.ExtraOptions{IsInteractiveShell: true, IsNormal: true})
+				responseObjects, responseTxt := helper.GetData(input, main_params, structs.ExtraOptions{IsInteractiveShell: true, IsNormal: true, IsThink: *isThink})
 				// Regex to match complete <cmd>...</cmd>
 				commandRegex := regexp.MustCompile(`<cmd>(.*?)</cmd>`)
 				matches := commandRegex.FindStringSubmatch(responseTxt)
@@ -781,11 +788,11 @@ func main() {
 
 					return
 				}
-				helper.MakeRequestAndGetData(*preprompt+trimmedPrompt+contextText+pipedInput, main_params, structs.ExtraOptions{IsGetSilent: true})
+				helper.MakeRequestAndGetData(*preprompt+trimmedPrompt+contextText+pipedInput, main_params, structs.ExtraOptions{IsGetSilent: true, IsThink: *isThink})
 			} else {
 				formattedInput := bubbletea.GetFormattedInputStdin()
 				fmt.Println()
-				helper.MakeRequestAndGetData(*preprompt+formattedInput+cleanPipedInput, main_params, structs.ExtraOptions{IsGetSilent: true})
+				helper.MakeRequestAndGetData(*preprompt+formattedInput+cleanPipedInput, main_params, structs.ExtraOptions{IsGetSilent: true, IsThink: *isThink})
 			}
 		default:
 			formattedInput := strings.TrimSpace(prompt)
@@ -800,7 +807,7 @@ func main() {
 				*preprompt+formattedInput+contextText+pipedInput,
 				main_params,
 				structs.ExtraOptions{
-					IsNormal: true, IsInteractive: false,
+					IsNormal: true, IsInteractive: false, IsThink: *isThink,
 				})
 		}
 
@@ -809,7 +816,7 @@ func main() {
 		scanner.Scan()
 		input := scanner.Text()
 		formattedInput := strings.TrimSpace(input)
-		helper.GetData(*preprompt+formattedInput+pipedInput, main_params, structs.ExtraOptions{IsInteractive: false})
+		helper.GetData(*preprompt+formattedInput+pipedInput, main_params, structs.ExtraOptions{IsInteractive: false, IsThink: *isThink})
 	}
 }
 

--- a/src/helper/helper.go
+++ b/src/helper/helper.go
@@ -311,13 +311,13 @@ func GetLastCodeBlock(markdown string) string {
 }
 
 var thinkingTagPatterns = []string{
-	"<think>",
 	"<thinking>",
+	"<think>",
 }
 
 var thinkingTagClosers = []string{
-	"</think>",
 	"</thinking>",
+	"</think>",
 }
 
 func isThinkingTag(text string) string {
@@ -727,8 +727,8 @@ func HandleEachPartInteractiveShell(resp *http.Response, input string, params st
 					(strings.HasPrefix(currentBuffer, "<search>") && strings.HasSuffix(currentBuffer, "</search>"))
 				isThinkingTag := strings.HasPrefix(currentBuffer, "<think>") ||
 					strings.HasPrefix(currentBuffer, "<thinking>") ||
-					strings.HasPrefix(currentBuffer, "</thinking>") ||
-					strings.HasSuffix(currentBuffer, "</think>")
+					strings.HasPrefix(currentBuffer, "</think>") ||
+					strings.HasPrefix(currentBuffer, "</thinking>")
 				if isSearchOrCmdTag || (isThinkingTag && !extraOptions.IsThink) {
 					xmlBuffer.Reset()
 					inXMLTag = false

--- a/src/helper/helper.go
+++ b/src/helper/helper.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/aandrew-me/tgpt/v2/src/client"
@@ -313,17 +314,11 @@ func GetLastCodeBlock(markdown string) string {
 var thinkingTagPatterns = []string{
 	"<think>",
 	"<thinking>",
-	"<reason>",
-	"<reasoning>",
-	"<step>",
 }
 
 var thinkingTagClosers = []string{
 	"</think>",
 	"</thinking>",
-	"</reason>",
-	"</reasoning>",
-	"</step>",
 }
 
 func isThinkingTag(text string) string {
@@ -349,8 +344,10 @@ func isThinkingCloser(text string) string {
 var thinkSpinnerDone chan bool
 var thinkSpinnerStop chan bool
 var thinkMutex sync.Mutex
+var thinkingSpinnerActive int32
 
 func startThinkingSpinner() {
+	atomic.StoreInt32(&thinkingSpinnerActive, 1)
 	thinkSpinnerDone = make(chan bool)
 	thinkSpinnerStop = make(chan bool)
 	go func() {
@@ -371,10 +368,13 @@ func startThinkingSpinner() {
 }
 
 func stopThinkingSpinner() {
-	if thinkSpinnerStop != nil {
-		thinkSpinnerStop <- true
-		<-thinkSpinnerDone
-		fmt.Printf("\r\033[2K\r")
+	if atomic.LoadInt32(&thinkingSpinnerActive) == 1 {
+		atomic.StoreInt32(&thinkingSpinnerActive, 0)
+		if thinkSpinnerStop != nil {
+			thinkSpinnerStop <- true
+			<-thinkSpinnerDone
+			fmt.Printf("\r\033[2K\r")
+		}
 	}
 }
 
@@ -432,14 +432,22 @@ func HandleEachPart(resp *http.Response, input string, params structs.Params, ex
 					stopThinkingSpinner()
 				}
 
-				parts := strings.Split(bufferedText, closer)
-				if len(parts) > 1 {
-					mainText = parts[1]
+				if extraOptions.IsThink {
+					mainText = bufferedText
+				} else {
+					parts := strings.Split(bufferedText, closer)
+					if len(parts) > 1 {
+						mainText = parts[1]
+					} else {
+						mainText = ""
+					}
+				}
+			} else {
+				if extraOptions.IsThink {
+					mainText = bufferedText
 				} else {
 					mainText = ""
 				}
-			} else {
-				mainText = ""
 			}
 		}
 
@@ -565,6 +573,8 @@ func HandleEachPart(resp *http.Response, input string, params structs.Params, ex
 		os.Exit(1)
 	}
 
+	stopThinkingSpinner()
+
 	return fullText
 
 }
@@ -628,14 +638,22 @@ func HandleEachPartInteractiveShell(resp *http.Response, input string, params st
 					stopThinkingSpinner()
 				}
 
-				parts := strings.Split(bufferedText, closer)
-				if len(parts) > 1 {
-					mainText = parts[1]
+				if extraOptions.IsThink {
+					mainText = bufferedText
+				} else {
+					parts := strings.Split(bufferedText, closer)
+					if len(parts) > 1 {
+						mainText = parts[1]
+					} else {
+						mainText = ""
+					}
+				}
+			} else {
+				if extraOptions.IsThink {
+					mainText = bufferedText
 				} else {
 					mainText = ""
 				}
-			} else {
-				mainText = ""
 			}
 		}
 
@@ -655,11 +673,18 @@ func HandleEachPartInteractiveShell(resp *http.Response, input string, params st
 				// Possibly end tag part
 				xmlBuffer.WriteRune(char)
 				currentBuffer := xmlBuffer.String()
-				if (strings.HasPrefix(currentBuffer, "<cmd>") && strings.HasSuffix(currentBuffer, "</cmd>")) ||
-					(strings.HasPrefix(currentBuffer, "<search>") && strings.HasSuffix(currentBuffer, "</search>")) {
+				isSearchOrCmdTag := (strings.HasPrefix(currentBuffer, "<cmd>") && strings.HasSuffix(currentBuffer, "</cmd>")) ||
+					(strings.HasPrefix(currentBuffer, "<search>") && strings.HasSuffix(currentBuffer, "</search>"))
+				isThinkingTag := strings.HasPrefix(currentBuffer, "<think>") ||
+					strings.HasPrefix(currentBuffer, "<thinking>") ||
+					strings.HasPrefix(currentBuffer, "</thinking>") ||
+					strings.HasPrefix(currentBuffer, "</reason")
+				if isSearchOrCmdTag || (isThinkingTag && !extraOptions.IsThink) {
 					xmlBuffer.Reset()
 					inXMLTag = false
-					// Don't print XML tags - they are processed separately
+					if !isThinkingTag {
+						// Don't print XML tags - they are processed separately
+					}
 				}
 			} else if inXMLTag {
 				// Inside XML tag, continue buffering
@@ -773,6 +798,8 @@ func HandleEachPartInteractiveShell(resp *http.Response, input string, params st
 		fmt.Fprintln(os.Stderr, "Error occurred:", err)
 		os.Exit(1)
 	}
+
+	stopThinkingSpinner()
 
 	return fullText
 }
@@ -1157,6 +1184,7 @@ func SearchQuery(input string, params structs.Params, extraOptions structs.Extra
 	searchOptions := structs.ExtraOptions{
 		IsGetSilent: isQuiet,
 		IsGetWhole:  false,
+		IsThink:     extraOptions.IsThink,
 	}
 
 	// Get AI response
@@ -1213,7 +1241,7 @@ func InteractiveFindSession(params structs.Params, extraOptions structs.ExtraOpt
 		params.SystemPrompt = promptFind
 
 		// Get AI response (this will print with Bot label)
-		responseObjects, responseTxt := GetData(input, params, structs.ExtraOptions{IsInteractiveFind: true, IsNormal: true})
+		responseObjects, responseTxt := GetData(input, params, structs.ExtraOptions{IsInteractiveFind: true, IsNormal: true, IsThink: extraOptions.IsThink})
 
 		// Check if response contains search intent
 		searchRegex := regexp.MustCompile(`<search>(.*?)</search>`)
@@ -1248,7 +1276,7 @@ func InteractiveFindSession(params structs.Params, extraOptions structs.ExtraOpt
 
 			// Update conversation with search context and get final response (this will print with Bot label)
 			params.PrevMessages = previousMessages
-			finalResponseObjects, finalResponseTxt := GetData(fmt.Sprintf("Based on these search results, answer the user's question: %s", input), params, structs.ExtraOptions{IsInteractiveFind: true, IsNormal: true})
+			finalResponseObjects, finalResponseTxt := GetData(fmt.Sprintf("Based on these search results, answer the user's question: %s", input), params, structs.ExtraOptions{IsInteractiveFind: true, IsNormal: true, IsThink: extraOptions.IsThink})
 
 			if len(logFile) > 0 {
 				utils.LogToFile(finalResponseTxt, "ASSISTANT_RESPONSE", logFile)

--- a/src/helper/helper.go
+++ b/src/helper/helper.go
@@ -406,20 +406,25 @@ func HandleEachPart(resp *http.Response, input string, params structs.Params, ex
 			continue
 		}
 
-		thinkBuffer.WriteString(mainText)
-		bufferedText := thinkBuffer.String()
-
-		if !inThinking {
-			if tag := isThinkingTag(bufferedText); tag != "" {
+		trimmedText := strings.TrimLeft(mainText, " \t\n\r")
+		if tag := isThinkingTag(trimmedText); tag != "" {
+			if !inThinking {
 				inThinking = true
 				currentThinkTag = tag
-				thinkBuffer.Reset()
 
 				if !extraOptions.IsThink {
 					startThinkingSpinner()
 				}
 			}
+			thinkBuffer.Reset()
+			tagLen := len(tag)
+			afterTag := trimmedText[tagLen:]
+			thinkBuffer.WriteString(afterTag)
+		} else if inThinking {
+			thinkBuffer.WriteString(mainText)
 		}
+
+		bufferedText := thinkBuffer.String()
 
 		if inThinking {
 			closer := strings.ToLower(currentThinkTag)
@@ -612,20 +617,25 @@ func HandleEachPartInteractiveShell(resp *http.Response, input string, params st
 			continue
 		}
 
-		thinkBuffer.WriteString(mainText)
-		bufferedText := thinkBuffer.String()
-
-		if !inThinking {
-			if tag := isThinkingTag(bufferedText); tag != "" {
+		trimmedText := strings.TrimLeft(mainText, " \t\n\r")
+		if tag := isThinkingTag(trimmedText); tag != "" {
+			if !inThinking {
 				inThinking = true
 				currentThinkTag = tag
-				thinkBuffer.Reset()
 
 				if !extraOptions.IsThink {
 					startThinkingSpinner()
 				}
 			}
+			thinkBuffer.Reset()
+			tagLen := len(tag)
+			afterTag := trimmedText[tagLen:]
+			thinkBuffer.WriteString(afterTag)
+		} else if inThinking {
+			thinkBuffer.WriteString(mainText)
 		}
+
+		bufferedText := thinkBuffer.String()
 
 		if inThinking {
 			closer := strings.ToLower(currentThinkTag)
@@ -972,20 +982,25 @@ func MakeRequestAndGetData(input string, params structs.Params, extraOptions str
 			continue
 		}
 
-		thinkBuffer.WriteString(mainText)
-		bufferedText := thinkBuffer.String()
-
-		if !inThinking {
-			if tag := isThinkingTag(bufferedText); tag != "" {
+		trimmedText := strings.TrimLeft(mainText, " \t\n\r")
+		if tag := isThinkingTag(trimmedText); tag != "" {
+			if !inThinking {
 				inThinking = true
 				currentThinkTag = tag
-				thinkBuffer.Reset()
 
 				if !extraOptions.IsThink {
 					startThinkingSpinner()
 				}
 			}
+			thinkBuffer.Reset()
+			tagLen := len(tag)
+			afterTag := trimmedText[tagLen:]
+			thinkBuffer.WriteString(afterTag)
+		} else if inThinking {
+			thinkBuffer.WriteString(mainText)
 		}
+
+		bufferedText := thinkBuffer.String()
 
 		if inThinking {
 			closer := strings.ToLower(currentThinkTag)

--- a/src/helper/helper.go
+++ b/src/helper/helper.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/aandrew-me/tgpt/v2/src/client"
@@ -309,7 +310,75 @@ func GetLastCodeBlock(markdown string) string {
 	return strings.Join(codeBlock, "\n")
 }
 
-func HandleEachPart(resp *http.Response, input string, params structs.Params) string {
+var thinkingTagPatterns = []string{
+	"<think>",
+	"<thinking>",
+	"<reason>",
+	"<reasoning>",
+	"<step>",
+}
+
+var thinkingTagClosers = []string{
+	"</think>",
+	"</thinking>",
+	"</reason>",
+	"</reasoning>",
+	"</step>",
+}
+
+func isThinkingTag(text string) string {
+	lowerText := strings.ToLower(text)
+	for _, tag := range thinkingTagPatterns {
+		if strings.HasPrefix(lowerText, tag) {
+			return tag
+		}
+	}
+	return ""
+}
+
+func isThinkingCloser(text string) string {
+	lowerText := strings.ToLower(text)
+	for _, tag := range thinkingTagClosers {
+		if strings.HasSuffix(lowerText, tag) {
+			return tag
+		}
+	}
+	return ""
+}
+
+var thinkSpinnerDone chan bool
+var thinkSpinnerStop chan bool
+var thinkMutex sync.Mutex
+
+func startThinkingSpinner() {
+	thinkSpinnerDone = make(chan bool)
+	thinkSpinnerStop = make(chan bool)
+	go func() {
+		spinnerChars := []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+		i := 0
+		for {
+			select {
+			case <-thinkSpinnerStop:
+				thinkSpinnerDone <- true
+				return
+			default:
+				fmt.Printf("\r\033[36m%s Thinking...\033[0m", spinnerChars[i])
+				i = (i + 1) % len(spinnerChars)
+				time.Sleep(80 * time.Millisecond)
+			}
+		}
+	}()
+}
+
+func stopThinkingSpinner() {
+	if thinkSpinnerStop != nil {
+		thinkSpinnerStop <- true
+		<-thinkSpinnerDone
+		fmt.Printf("\r\033[2K\r")
+	}
+}
+
+func HandleEachPart(resp *http.Response, input string, params structs.Params, extraOptions structs.ExtraOptions) string {
 	scanner := bufio.NewScanner(resp.Body)
 
 	// Variables
@@ -327,11 +396,57 @@ func HandleEachPart(resp *http.Response, input string, params structs.Params) st
 
 	fullText := ""
 
+	var thinkBuffer strings.Builder
+	inThinking := false
+	var currentThinkTag string
+
 	for scanner.Scan() {
 		mainText := providers.GetMainText(scanner.Text(), params.Provider, input)
 		if len(mainText) < 1 {
 			continue
 		}
+
+		thinkBuffer.WriteString(mainText)
+		bufferedText := thinkBuffer.String()
+
+		if !inThinking {
+			if tag := isThinkingTag(bufferedText); tag != "" {
+				inThinking = true
+				currentThinkTag = tag
+				thinkBuffer.Reset()
+
+				if !extraOptions.IsThink {
+					startThinkingSpinner()
+				}
+			}
+		}
+
+		if inThinking {
+			closer := strings.ToLower(currentThinkTag)
+			closer = strings.Replace(closer, "<", "</", 1)
+			if strings.Contains(bufferedText, closer) {
+				inThinking = false
+				thinkBuffer.Reset()
+
+				if !extraOptions.IsThink {
+					stopThinkingSpinner()
+				}
+
+				parts := strings.Split(bufferedText, closer)
+				if len(parts) > 1 {
+					mainText = parts[1]
+				} else {
+					mainText = ""
+				}
+			} else {
+				mainText = ""
+			}
+		}
+
+		if mainText == "" {
+			continue
+		}
+
 		fullText += mainText
 
 		if count <= 0 {
@@ -455,7 +570,7 @@ func HandleEachPart(resp *http.Response, input string, params structs.Params) st
 }
 
 // handle response for interactive shell mode
-func HandleEachPartInteractiveShell(resp *http.Response, input string, params structs.Params) string {
+func HandleEachPartInteractiveShell(resp *http.Response, input string, params structs.Params, extraOptions structs.ExtraOptions) string {
 	scanner := bufio.NewScanner(resp.Body)
 
 	// Variables for formatting
@@ -472,6 +587,10 @@ func HandleEachPartInteractiveShell(resp *http.Response, input string, params st
 	termWidth := size.Col()
 
 	fullText := ""
+	var thinkBuffer strings.Builder
+	inThinking := false
+	var currentThinkTag string
+
 	// Buffer for incomplete XML tags
 	var xmlBuffer strings.Builder
 	// Track if inside XML tag
@@ -480,6 +599,47 @@ func HandleEachPartInteractiveShell(resp *http.Response, input string, params st
 	for scanner.Scan() {
 		mainText := providers.GetMainText(scanner.Text(), params.Provider, input)
 		if len(mainText) < 1 {
+			continue
+		}
+
+		thinkBuffer.WriteString(mainText)
+		bufferedText := thinkBuffer.String()
+
+		if !inThinking {
+			if tag := isThinkingTag(bufferedText); tag != "" {
+				inThinking = true
+				currentThinkTag = tag
+				thinkBuffer.Reset()
+
+				if !extraOptions.IsThink {
+					startThinkingSpinner()
+				}
+			}
+		}
+
+		if inThinking {
+			closer := strings.ToLower(currentThinkTag)
+			closer = strings.Replace(closer, "<", "</", 1)
+			if strings.Contains(bufferedText, closer) {
+				inThinking = false
+				thinkBuffer.Reset()
+
+				if !extraOptions.IsThink {
+					stopThinkingSpinner()
+				}
+
+				parts := strings.Split(bufferedText, closer)
+				if len(parts) > 1 {
+					mainText = parts[1]
+				} else {
+					mainText = ""
+				}
+			} else {
+				mainText = ""
+			}
+		}
+
+		if mainText == "" {
 			continue
 		}
 
@@ -759,12 +919,12 @@ func MakeRequestAndGetData(input string, params structs.Params, extraOptions str
 
 		// Handling each part
 		if extraOptions.IsInteractiveShell {
-			return HandleEachPartInteractiveShell(resp, input, params)
+			return HandleEachPartInteractiveShell(resp, input, params, extraOptions)
 		}
 		if extraOptions.IsInteractiveFind {
-			return HandleEachPartInteractiveShell(resp, input, params) // Use same formatting as interactive shell
+			return HandleEachPartInteractiveShell(resp, input, params, extraOptions) // Use same formatting as interactive shell
 		}
-		return HandleEachPart(resp, input, params)
+		return HandleEachPart(resp, input, params, extraOptions)
 	}
 
 	if extraOptions.IsGetCommand {
@@ -775,12 +935,57 @@ func MakeRequestAndGetData(input string, params structs.Params, extraOptions str
 
 	// Handling each part
 	fullText := ""
+	var thinkBuffer strings.Builder
+	inThinking := false
+	var currentThinkTag string
 
 	for scanner.Scan() {
 		mainText := providers.GetMainText(scanner.Text(), params.Provider, input)
 		if len(mainText) < 1 {
 			continue
 		}
+
+		thinkBuffer.WriteString(mainText)
+		bufferedText := thinkBuffer.String()
+
+		if !inThinking {
+			if tag := isThinkingTag(bufferedText); tag != "" {
+				inThinking = true
+				currentThinkTag = tag
+				thinkBuffer.Reset()
+
+				if !extraOptions.IsThink {
+					startThinkingSpinner()
+				}
+			}
+		}
+
+		if inThinking {
+			closer := strings.ToLower(currentThinkTag)
+			closer = strings.Replace(closer, "<", "</", 1)
+			if strings.Contains(bufferedText, closer) {
+				inThinking = false
+				thinkBuffer.Reset()
+
+				if !extraOptions.IsThink {
+					stopThinkingSpinner()
+				}
+
+				parts := strings.Split(bufferedText, closer)
+				if len(parts) > 1 {
+					mainText = parts[1]
+				} else {
+					mainText = ""
+				}
+			} else {
+				mainText = ""
+			}
+		}
+
+		if mainText == "" {
+			continue
+		}
+
 		fullText += mainText
 
 		if !extraOptions.IsGetWhole {
@@ -858,6 +1063,7 @@ func ShowHelpMessage() {
 	boldBlue.Println("\nOptions:")
 	fmt.Printf("%-50v Print version \n", "-v, --version")
 	fmt.Printf("%-50v Print help message \n", "-h, --help")
+	fmt.Printf("%-50v Show thinking process from the AI \n", "-t, --think")
 	fmt.Printf("%-50v Start normal interactive mode \n", "-i, --interactive")
 	fmt.Printf("%-50v Start multi-line interactive mode \n", "-m, --multiline")
 	fmt.Printf("%-50v Start interactive shell mode. (Doesn't work with all providers) \n", "-is, --interactive-shell")

--- a/src/helper/helper.go
+++ b/src/helper/helper.go
@@ -10,7 +10,6 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -331,6 +330,17 @@ func isThinkingTag(text string) string {
 	return ""
 }
 
+func findThinkingTag(text string) (tag string, index int) {
+	lowerText := strings.ToLower(text)
+	for _, tag := range thinkingTagPatterns {
+		idx := strings.Index(lowerText, tag)
+		if idx != -1 {
+			return tag, idx
+		}
+	}
+	return "", -1
+}
+
 func isThinkingCloser(text string) string {
 	lowerText := strings.ToLower(text)
 	for _, tag := range thinkingTagClosers {
@@ -343,10 +353,12 @@ func isThinkingCloser(text string) string {
 
 var thinkSpinnerDone chan bool
 var thinkSpinnerStop chan bool
-var thinkMutex sync.Mutex
 var thinkingSpinnerActive int32
 
 func startThinkingSpinner() {
+	if atomic.LoadInt32(&thinkingSpinnerActive) == 1 {
+		return
+	}
 	atomic.StoreInt32(&thinkingSpinnerActive, 1)
 	thinkSpinnerDone = make(chan bool)
 	thinkSpinnerStop = make(chan bool)
@@ -407,8 +419,15 @@ func HandleEachPart(resp *http.Response, input string, params structs.Params, ex
 		}
 
 		trimmedText := strings.TrimLeft(mainText, " \t\n\r")
-		if tag := isThinkingTag(trimmedText); tag != "" {
-			if !inThinking {
+
+		tag, tagIdx := findThinkingTag(trimmedText)
+		if tag != "" {
+			preTag := trimmedText[:tagIdx]
+			postTag := trimmedText[tagIdx:]
+
+			isClosingTag := strings.HasPrefix(strings.ToLower(postTag), "</")
+
+			if !inThinking && !isClosingTag {
 				inThinking = true
 				currentThinkTag = tag
 
@@ -416,12 +435,24 @@ func HandleEachPart(resp *http.Response, input string, params structs.Params, ex
 					startThinkingSpinner()
 				}
 			}
-			thinkBuffer.Reset()
-			tagLen := len(tag)
-			afterTag := trimmedText[tagLen:]
-			thinkBuffer.WriteString(afterTag)
+
+			if preTag != "" && !inThinking {
+				mainText = preTag
+			} else {
+				thinkBuffer.Reset()
+				if extraOptions.IsThink {
+					thinkBuffer.WriteString(trimmedText)
+				} else {
+					tagLen := len(tag)
+					if tagLen < len(postTag) {
+						thinkBuffer.WriteString(postTag[tagLen:])
+					}
+				}
+			}
 		} else if inThinking {
 			thinkBuffer.WriteString(mainText)
+		} else {
+			mainText = mainText
 		}
 
 		bufferedText := thinkBuffer.String()
@@ -618,8 +649,15 @@ func HandleEachPartInteractiveShell(resp *http.Response, input string, params st
 		}
 
 		trimmedText := strings.TrimLeft(mainText, " \t\n\r")
-		if tag := isThinkingTag(trimmedText); tag != "" {
-			if !inThinking {
+
+		tag, tagIdx := findThinkingTag(trimmedText)
+		if tag != "" {
+			preTag := trimmedText[:tagIdx]
+			postTag := trimmedText[tagIdx:]
+
+			isClosingTag := strings.HasPrefix(strings.ToLower(postTag), "</")
+
+			if !inThinking && !isClosingTag {
 				inThinking = true
 				currentThinkTag = tag
 
@@ -627,12 +665,24 @@ func HandleEachPartInteractiveShell(resp *http.Response, input string, params st
 					startThinkingSpinner()
 				}
 			}
-			thinkBuffer.Reset()
-			tagLen := len(tag)
-			afterTag := trimmedText[tagLen:]
-			thinkBuffer.WriteString(afterTag)
+
+			if preTag != "" && !inThinking {
+				mainText = preTag
+			} else {
+				thinkBuffer.Reset()
+				if extraOptions.IsThink {
+					thinkBuffer.WriteString(trimmedText)
+				} else {
+					tagLen := len(tag)
+					if tagLen < len(postTag) {
+						thinkBuffer.WriteString(postTag[tagLen:])
+					}
+				}
+			}
 		} else if inThinking {
 			thinkBuffer.WriteString(mainText)
+		} else {
+			mainText = mainText
 		}
 
 		bufferedText := thinkBuffer.String()
@@ -687,8 +737,7 @@ func HandleEachPartInteractiveShell(resp *http.Response, input string, params st
 					(strings.HasPrefix(currentBuffer, "<search>") && strings.HasSuffix(currentBuffer, "</search>"))
 				isThinkingTag := strings.HasPrefix(currentBuffer, "<think>") ||
 					strings.HasPrefix(currentBuffer, "<thinking>") ||
-					strings.HasPrefix(currentBuffer, "</thinking>") ||
-					strings.HasPrefix(currentBuffer, "</reason")
+					strings.HasPrefix(currentBuffer, "</thinking>")
 				if isSearchOrCmdTag || (isThinkingTag && !extraOptions.IsThink) {
 					xmlBuffer.Reset()
 					inXMLTag = false
@@ -983,8 +1032,15 @@ func MakeRequestAndGetData(input string, params structs.Params, extraOptions str
 		}
 
 		trimmedText := strings.TrimLeft(mainText, " \t\n\r")
-		if tag := isThinkingTag(trimmedText); tag != "" {
-			if !inThinking {
+
+		tag, tagIdx := findThinkingTag(trimmedText)
+		if tag != "" {
+			preTag := trimmedText[:tagIdx]
+			postTag := trimmedText[tagIdx:]
+
+			isClosingTag := strings.HasPrefix(strings.ToLower(postTag), "</")
+
+			if !inThinking && !isClosingTag {
 				inThinking = true
 				currentThinkTag = tag
 
@@ -992,12 +1048,24 @@ func MakeRequestAndGetData(input string, params structs.Params, extraOptions str
 					startThinkingSpinner()
 				}
 			}
-			thinkBuffer.Reset()
-			tagLen := len(tag)
-			afterTag := trimmedText[tagLen:]
-			thinkBuffer.WriteString(afterTag)
+
+			if preTag != "" && !inThinking {
+				mainText = preTag
+			} else {
+				thinkBuffer.Reset()
+				if extraOptions.IsThink {
+					thinkBuffer.WriteString(trimmedText)
+				} else {
+					tagLen := len(tag)
+					if tagLen < len(postTag) {
+						thinkBuffer.WriteString(postTag[tagLen:])
+					}
+				}
+			}
 		} else if inThinking {
 			thinkBuffer.WriteString(mainText)
+		} else {
+			mainText = mainText
 		}
 
 		bufferedText := thinkBuffer.String()
@@ -1013,14 +1081,22 @@ func MakeRequestAndGetData(input string, params structs.Params, extraOptions str
 					stopThinkingSpinner()
 				}
 
-				parts := strings.Split(bufferedText, closer)
-				if len(parts) > 1 {
-					mainText = parts[1]
+				if extraOptions.IsThink {
+					mainText = bufferedText
+				} else {
+					parts := strings.Split(bufferedText, closer)
+					if len(parts) > 1 {
+						mainText = parts[1]
+					} else {
+						mainText = ""
+					}
+				}
+			} else {
+				if extraOptions.IsThink {
+					mainText = bufferedText
 				} else {
 					mainText = ""
 				}
-			} else {
-				mainText = ""
 			}
 		}
 

--- a/src/helper/helper.go
+++ b/src/helper/helper.go
@@ -451,8 +451,6 @@ func HandleEachPart(resp *http.Response, input string, params structs.Params, ex
 			}
 		} else if inThinking {
 			thinkBuffer.WriteString(mainText)
-		} else {
-			mainText = mainText
 		}
 
 		bufferedText := thinkBuffer.String()
@@ -479,11 +477,8 @@ func HandleEachPart(resp *http.Response, input string, params structs.Params, ex
 					}
 				}
 			} else {
-				if extraOptions.IsThink {
-					mainText = bufferedText
-				} else {
-					mainText = ""
-				}
+				// Still accumulating thinking content, don't output yet
+				mainText = ""
 			}
 		}
 
@@ -681,8 +676,6 @@ func HandleEachPartInteractiveShell(resp *http.Response, input string, params st
 			}
 		} else if inThinking {
 			thinkBuffer.WriteString(mainText)
-		} else {
-			mainText = mainText
 		}
 
 		bufferedText := thinkBuffer.String()
@@ -709,11 +702,8 @@ func HandleEachPartInteractiveShell(resp *http.Response, input string, params st
 					}
 				}
 			} else {
-				if extraOptions.IsThink {
-					mainText = bufferedText
-				} else {
-					mainText = ""
-				}
+				// Still accumulating thinking content, don't output yet
+				mainText = ""
 			}
 		}
 
@@ -737,7 +727,8 @@ func HandleEachPartInteractiveShell(resp *http.Response, input string, params st
 					(strings.HasPrefix(currentBuffer, "<search>") && strings.HasSuffix(currentBuffer, "</search>"))
 				isThinkingTag := strings.HasPrefix(currentBuffer, "<think>") ||
 					strings.HasPrefix(currentBuffer, "<thinking>") ||
-					strings.HasPrefix(currentBuffer, "</thinking>")
+					strings.HasPrefix(currentBuffer, "</thinking>") ||
+					strings.HasSuffix(currentBuffer, "</think>")
 				if isSearchOrCmdTag || (isThinkingTag && !extraOptions.IsThink) {
 					xmlBuffer.Reset()
 					inXMLTag = false
@@ -1064,8 +1055,6 @@ func MakeRequestAndGetData(input string, params structs.Params, extraOptions str
 			}
 		} else if inThinking {
 			thinkBuffer.WriteString(mainText)
-		} else {
-			mainText = mainText
 		}
 
 		bufferedText := thinkBuffer.String()
@@ -1092,11 +1081,8 @@ func MakeRequestAndGetData(input string, params structs.Params, extraOptions str
 					}
 				}
 			} else {
-				if extraOptions.IsThink {
-					mainText = bufferedText
-				} else {
-					mainText = ""
-				}
+				// Still accumulating thinking content, don't output yet
+				mainText = ""
 			}
 		}
 
@@ -1112,9 +1098,12 @@ func MakeRequestAndGetData(input string, params structs.Params, extraOptions str
 	}
 
 	if err := scanner.Err(); err != nil {
+		stopThinkingSpinner()
 		fmt.Fprintln(os.Stderr, "Some error has occurred. Error:", err)
 		os.Exit(1)
 	}
+
+	stopThinkingSpinner()
 
 	if extraOptions.IsGetWhole {
 		fmt.Println(fullText)

--- a/src/helper/helper.go
+++ b/src/helper/helper.go
@@ -315,21 +315,6 @@ var thinkingTagPatterns = []string{
 	"<think>",
 }
 
-var thinkingTagClosers = []string{
-	"</thinking>",
-	"</think>",
-}
-
-func isThinkingTag(text string) string {
-	lowerText := strings.ToLower(text)
-	for _, tag := range thinkingTagPatterns {
-		if strings.HasPrefix(lowerText, tag) {
-			return tag
-		}
-	}
-	return ""
-}
-
 func findThinkingTag(text string) (tag string, index int) {
 	lowerText := strings.ToLower(text)
 	for _, tag := range thinkingTagPatterns {
@@ -339,16 +324,6 @@ func findThinkingTag(text string) (tag string, index int) {
 		}
 	}
 	return "", -1
-}
-
-func isThinkingCloser(text string) string {
-	lowerText := strings.ToLower(text)
-	for _, tag := range thinkingTagClosers {
-		if strings.HasSuffix(lowerText, tag) {
-			return tag
-		}
-	}
-	return ""
 }
 
 var thinkSpinnerDone chan bool

--- a/src/structs/structs.go
+++ b/src/structs/structs.go
@@ -26,6 +26,7 @@ type ExtraOptions struct {
 	IsFind             bool // IsFind enable web search functionality
 	IsInteractiveFind  bool // IsInteractiveFind enable interactive web search mode
 	Verbose            bool // Verbose enable detailed search output
+	IsThink            bool // IsThink show thinking tags or hide them with animation
 }
 
 type CommonResponse struct {


### PR DESCRIPTION
Implements -t/--think flag that controls visibility of AI thinking tags (`<think>`, `<thinking>`, etc.). When disabled (default), thinking content is hidden and a spinner animation displays during reasoning. When enabled, the raw thinking process is shown in the output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command-line flag (`-t` / `--think`) to optionally reveal the AI’s internal “thinking” output.
  * “Thinking” handling is now consistent across standard, interactive shell, code generation, and search/find workflows.
  * When thinking is hidden, it’s buffered and omitted from the final output, with a “Thinking…” indicator shown while it’s suppressed.

* **Documentation**
  * Updated the help text to include the new thinking flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->