### PR TITLE
Add opencode provider (free, OpenAI-compatible)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ CLAUDE.md
 
 # Tools directory - development/testing utilities
 tools/
+.opencode/

--- a/md/providers.md
+++ b/md/providers.md
@@ -7,6 +7,7 @@
 - [MiniMax](https://platform.minimaxi.com/) (Requires API key, default model `MiniMax-M2.7`)
 - [Ollama](https://www.ollama.com/) (Local models) (Supports many models)
 - [OpenAI](https://platform.openai.com/docs/guides/text-generation/chat-completions-api) (All models, Requires API Key, supports custom endpoints)
+- [OpenCode](https://opencode.ai) (Free, uses opencode.ai/zen API, default model deepseek-v4-flash-free, default API key `public`, supports OPENCODE_API_KEY / OPENCODE_MODEL / OPENCODE_URL env vars)
 - [Pollinations](https://pollinations.ai/) ([Many free models](https://text.pollinations.ai/models))
 - [Gemini](https://gemini.google.com) (Require a free API keys, supports [many models](https://ai.google.dev/gemini-api/docs/models/gemini), default model `gemini-2.0-flash`)
 

--- a/src/helper/helper.go
+++ b/src/helper/helper.go
@@ -872,7 +872,7 @@ func ShowHelpMessage() {
 
 	boldBlue.Println("\nProviders:")
 	fmt.Println("The default provider is pollinations. The AI_PROVIDER environment variable can be used to specify a different provider.")
-	fmt.Println("Available providers to use: deepseek, gemini, groq, isou, koboldai, minimax, ollama, openai, sky and pollinations")
+	fmt.Println("Available providers to use: deepseek, gemini, groq, isou, koboldai, minimax, ollama, openai, opencode, pollinations, powerbrain and sky")
 
 	bold.Println("\nProvider: deepseek")
 	fmt.Println("Uses deepseek-reasoner model by default. Requires API key. Recognizes the DEEPSEEK_API_KEY and DEEPSEEK_MODEL environment variables")
@@ -894,6 +894,9 @@ func ShowHelpMessage() {
 
 	bold.Println("\nProvider: ollama")
 	fmt.Println("Needs to be run locally. Supports many models")
+
+	bold.Println("\nProvider: opencode")
+	fmt.Println("Free provider using opencode.ai/zen API. Uses deepseek-v4-flash-free model by default. API key defaults to 'public'. Recognizes the OPENCODE_API_KEY, OPENCODE_MODEL and OPENCODE_URL environment variables.")
 
 	bold.Println("\nProvider: openai")
 	fmt.Println("Needs API key to work and supports various models. Recognizes the OPENAI_API_KEY and OPENAI_MODEL environment variables. Supports custom urls with --url")

--- a/src/helper/helper.go
+++ b/src/helper/helper.go
@@ -872,7 +872,7 @@ func ShowHelpMessage() {
 
 	boldBlue.Println("\nProviders:")
 	fmt.Println("The default provider is pollinations. The AI_PROVIDER environment variable can be used to specify a different provider.")
-	fmt.Println("Available providers to use: deepseek, gemini, groq, isou, koboldai, minimax, ollama, openai, opencode, pollinations, powerbrain and sky")
+	fmt.Println("Available providers to use: deepseek, gemini, groq, isou, kimi, koboldai, minimax, ollama, openai, opencode, pollinations, powerbrain and sky")
 
 	bold.Println("\nProvider: deepseek")
 	fmt.Println("Uses deepseek-reasoner model by default. Requires API key. Recognizes the DEEPSEEK_API_KEY and DEEPSEEK_MODEL environment variables")

--- a/src/providers/opencode/opencode.go
+++ b/src/providers/opencode/opencode.go
@@ -1,0 +1,112 @@
+package opencode
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	http "github.com/bogdanfinn/fhttp"
+
+	"github.com/aandrew-me/tgpt/v2/src/client"
+	"github.com/aandrew-me/tgpt/v2/src/structs"
+)
+
+type RequestBody struct {
+	Model    string `json:"model"`
+	Stream   bool   `json:"stream"`
+	Messages []any  `json:"messages"`
+}
+
+func NewRequest(input string, params structs.Params) (*http.Response, error) {
+	client, err := client.NewClient()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(0)
+	}
+
+	model := "deepseek-v4-flash-free"
+	if params.ApiModel != "" {
+		model = params.ApiModel
+	} else if envModel := os.Getenv("OPENCODE_MODEL"); envModel != "" {
+		model = envModel
+	}
+
+	apiKey := "public"
+	if params.ApiKey != "" {
+		apiKey = params.ApiKey
+	} else if envKey := os.Getenv("OPENCODE_API_KEY"); envKey != "" {
+		apiKey = envKey
+	}
+
+	url := params.Url
+	if url == "" {
+		if envUrl := os.Getenv("OPENCODE_URL"); envUrl != "" {
+			url = envUrl + "/v1/chat/completions"
+		}
+	}
+
+	if url == "" {
+		url = "https://opencode.ai/zen/v1/chat/completions"
+	}
+
+	requestInfo := RequestBody{
+		Model:  model,
+		Stream: true,
+		Messages: []any{
+			structs.DefaultMessage{
+				Content: params.SystemPrompt,
+				Role:    "system",
+			},
+		},
+	}
+
+	if len(params.PrevMessages) > 0 {
+		requestInfo.Messages = append(requestInfo.Messages, params.PrevMessages...)
+	}
+
+	requestInfo.Messages = append(requestInfo.Messages, structs.DefaultMessage{
+		Role:    "user",
+		Content: input,
+	})
+
+	jsonRequest, err := json.Marshal(requestInfo)
+
+	if err != nil {
+		log.Fatal("Failed to build user request")
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonRequest))
+
+	if err != nil {
+		log.Fatal("Some error has occured.\nError:", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	if apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+
+	return client.Do(req)
+}
+
+func GetMainText(line string) (mainText string) {
+	var obj = "{}"
+	if len(line) > 1 {
+		obj = strings.Split(line, "data: ")[1]
+	}
+
+	var d structs.CommonResponse
+	if err := json.Unmarshal([]byte(obj), &d); err != nil {
+		return ""
+	}
+
+	if len(d.Choices) > 0 {
+		mainText = d.Choices[0].Delta.Content
+		return mainText
+	}
+	return ""
+}

--- a/src/providers/providers.go
+++ b/src/providers/providers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aandrew-me/tgpt/v2/src/providers/koboldai"
 	"github.com/aandrew-me/tgpt/v2/src/providers/minimax"
 	"github.com/aandrew-me/tgpt/v2/src/providers/ollama"
+	"github.com/aandrew-me/tgpt/v2/src/providers/opencode"
 	"github.com/aandrew-me/tgpt/v2/src/providers/openai"
 	"github.com/aandrew-me/tgpt/v2/src/providers/pollinations"
 	"github.com/aandrew-me/tgpt/v2/src/providers/powerbrain"
@@ -21,7 +22,7 @@ import (
 )
 
 var availableProviders = []string{
-	"", "deepseek", "isou", "gemini", "groq", "kimi", "koboldai", "minimax", "ollama", "openai", "pollinations", "powerbrain", "sky",
+	"", "deepseek", "isou", "gemini", "groq", "kimi", "koboldai", "minimax", "ollama", "opencode", "openai", "pollinations", "powerbrain", "sky",
 }
 
 func GetMainText(line string, provider string, input string) string {
@@ -42,6 +43,8 @@ func GetMainText(line string, provider string, input string) string {
 		return minimax.GetMainText(line)
 	case "ollama":
 		return ollama.GetMainText(line)
+	case "opencode":
+		return opencode.GetMainText(line)
 	case "openai":
 		return openai.GetMainText(line)
 	case "pollinations":
@@ -85,6 +88,8 @@ func NewRequest(input string, params structs.Params, extraOptions structs.ExtraO
 		return minimax.NewRequest(input, params)
 	case "ollama":
 		return ollama.NewRequest(input, params)
+	case "opencode":
+		return opencode.NewRequest(input, params)
 	case "openai":
 		return openai.NewRequest(input, params)
 	case "pollinations":


### PR DESCRIPTION
Adds support for [opencode.ai](https://opencode.ai/zen) as a new provider in tgpt.

### Features
- OpenAI-compatible API format (reuses existing infrastructure)
- Free to use with default API key `public`
- Default model: `deepseek-v4-flash-free`
- Environment variable support: `OPENCODE_API_KEY`, `OPENCODE_MODEL`, `OPENCODE_URL`
- No API key required — works out of the box

### Usage
```
tgpt --provider opencode "your prompt"
```

Or set `AI_PROVIDER=opencode` as the default provider.

### Testing
- `go build ./...` — passes
- `go test ./...` — all existing tests pass (no regressions)
- `go vet ./...` — no new issues introduced (pre-existing vet warnings in `imagegen/pollinations` are unrelated)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the OpenCode (opencode) provider for streaming chat completions.
  * Added provider documentation and in-app help, including default model, endpoint, and API key guidance.
  * Updated provider routing so streamed responses are parsed and displayed consistently.
* **Chores**
  * Updated ignore rules to exclude the `tools/` and `.opencode/` directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->