### PR TITLE
fix: remove invalid os.Stderr arg from log.Fatal calls in imagegen/pollinations

### DIFF
--- a/src/imagegen/pollinations/pollinations.go
+++ b/src/imagegen/pollinations/pollinations.go
@@ -75,7 +75,7 @@ func GenerateImagePollinations(prompt string, params structs.ImageParams) string
 	res, err := client.Do(req)
 
 	if err != nil {
-		log.Fatal(os.Stderr, err)
+		log.Fatal(err)
 	}
 
 	defer res.Body.Close()
@@ -89,7 +89,7 @@ func GenerateImagePollinations(prompt string, params structs.ImageParams) string
 
 	file, err := os.Create(filepath)
 	if err != nil {
-		log.Fatal(os.Stderr, "Error: %v", err)
+		log.Fatalf("Error: %v", err)
 	}
 	defer file.Close()
 
@@ -97,7 +97,7 @@ func GenerateImagePollinations(prompt string, params structs.ImageParams) string
 	_, err = io.Copy(file, res.Body)
 
 	if err != nil {
-		log.Fatal(os.Stderr, "Error: %v", err)
+		log.Fatalf("Error: %v", err)
 	}
 
 	return filepath


### PR DESCRIPTION
Fixes pre-existing  warnings in .

## Problem
Three  calls pass  as first argument, but  does not accept an  — it always writes to stderr. This causes  failures.

## Fix
- Line 78:  → 
- Line 92:  → 
- Line 100:  → 

## Verification
-  — **passes** (previously 3 warnings, now zero)
-  — passes
- ?   	github.com/aandrew-me/tgpt/v2	[no test files]
?   	github.com/aandrew-me/tgpt/v2/src/bubbletea	[no test files]
?   	github.com/aandrew-me/tgpt/v2/src/client	[no test files]
?   	github.com/aandrew-me/tgpt/v2/src/clipboard	[no test files]
?   	github.com/aandrew-me/tgpt/v2/src/helper	[no test files]
?   	github.com/aandrew-me/tgpt/v2/src/imagegen	[no test files]
?   	github.com/aandrew-me/tgpt/v2/src/imagegen/arta	[no test files]
?   	github.com/aandrew-me/tgpt/v2/src/imagegen/pollinations	[no test files]
?   	github.com/aandrew-me/tgpt/v2/src/providers	[no test files]
?   	github.com/aandrew-me/tgpt/v2/src/providers/deepseek	[no test files]
?   	github.com/aandrew-me/tgpt/v2/src/providers/duckduckgo	[no test files]
?   	github.com/aandrew-me/tgpt/v2/src/providers/gemini	[no test files]
?   	github.com/aandrew-me/tgpt/v2/src/providers/groq	[no test files]
?   	github.com/aandrew-me/tgpt/v2/src/providers/isou	[no test files]
?   	github.com/aandrew-me/tgpt/v2/src/providers/kimi	[no test files]
ok  	github.com/aandrew-me/tgpt/v2/src/providers/koboldai	(cached)
ok  	github.com/aandrew-me/tgpt/v2/src/providers/minimax	(cached)
?   	github.com/aandrew-me/tgpt/v2/src/providers/ollama	[no test files]
?   	github.com/aandrew-me/tgpt/v2/src/providers/openai	[no test files]
?   	github.com/aandrew-me/tgpt/v2/src/providers/opencode	[no test files]
?   	github.com/aandrew-me/tgpt/v2/src/providers/pollinations	[no test files]
?   	github.com/aandrew-me/tgpt/v2/src/providers/powerbrain	[no test files]
?   	github.com/aandrew-me/tgpt/v2/src/providers/sky	[no test files]
?   	github.com/aandrew-me/tgpt/v2/src/search	[no test files]
?   	github.com/aandrew-me/tgpt/v2/src/structs	[no test files]
?   	github.com/aandrew-me/tgpt/v2/src/utils	[no test files] — all tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting when generating images, including clearer messages for request, file creation, and file writing failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->