### PR TITLE
fix: make AI_API_KEY env var work as default for --key flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -65,7 +65,7 @@ func main() {
 
 	apiModel = flag.String("model", "", "Choose which model to use")
 	provider = flag.String("provider", "", "Choose which provider to use")
-	apiKey = flag.String("key", "", "Use personal API Key")
+	apiKey = flag.String("key", os.Getenv("AI_API_KEY"), "Use personal API Key")
 	temperature = flag.String("temperature", os.Getenv("TGPT_TEMPERATURE"), "Set temperature")
 	top_p = flag.String("top_p", os.Getenv("TGPT_TOP_P"), "Set top_p")
 	preprompt = flag.String("preprompt", "", "Set preprompt")


### PR DESCRIPTION
Fixes #420

## Problem
The help message says `--key` supports env var `AI_API_KEY`, but it was never read. Only `gemini` and `openai` providers individually checked for it.

## Fix
Changed `main.go` line 68 to use `AI_API_KEY` as the default value for `--key`:
```go
apiKey = flag.String("key", os.Getenv("AI_API_KEY"), "Use personal API Key")```

This makes `AI_API_KEY` work for all providers automatically via `params.ApiKey`. Explicit `--key` still overrides.

## Verification
- `go build ./...` — passes
- `go vet ./...` — no new issues (pre-existing imagegen/pollinations warnings unrelated)
- `go test ./...` — all tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The API key can now be provided through the `AI_API_KEY` environment variable by default.
  * Command-line configuration remains available for overriding the environment-provided value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->