### PR TITLE
feat: add anyapi provider (chat + image gen)

### DIFF
--- a/md/providers.md
+++ b/md/providers.md
@@ -1,5 +1,6 @@
 ### Currently available providers
 
+- [AnyAPI](https://docs.anyapi.ai/) (Multi-model API, 100k free anytokens/day, supports chat and image gen, many providers including deepseek, google, openai)
 - [Deepseek](https://www.deepseek.com/) (Requires API key)
 - [Groq](https://groq.com/) (Requires a free API Key. [Many models](https://console.groq.com/docs/models))
 - [Isou](https://isou.chat/) (Free) (Deepseek-chat with SEARXNG)

--- a/md/providers.md
+++ b/md/providers.md
@@ -14,5 +14,6 @@
 - [Gemini](https://gemini.google.com) (Require a free API keys, supports [many models](https://ai.google.dev/gemini-api/docs/models/gemini), default model `gemini-2.0-flash`)
 
 **Image Generation Models**: 
+- AnyAPI (Requires API key, 100k anytokens/day)
 - Arta (Free)
 - Pollinations (Free) ([Models](https://image.pollinations.ai/models))

--- a/src/helper/helper.go
+++ b/src/helper/helper.go
@@ -872,7 +872,10 @@ func ShowHelpMessage() {
 
 	boldBlue.Println("\nProviders:")
 	fmt.Println("The default provider is pollinations. The AI_PROVIDER environment variable can be used to specify a different provider.")
-	fmt.Println("Available providers to use: deepseek, gemini, groq, isou, kimi, koboldai, minimax, ollama, ollamacloud, openai, opencode, pollinations, powerbrain and sky")
+	fmt.Println("Available providers to use: anyapi, deepseek, gemini, groq, isou, kimi, koboldai, minimax, ollama, ollamacloud, openai, opencode, pollinations, powerbrain and sky")
+
+	bold.Println("\nProvider: anyapi")
+	fmt.Println("Multi-model API with 100k free anytokens per day. Requires API key via ANYAPI_API_KEY env var or --key flag. Default model: openai/gpt-4o-mini. Recognizes ANYAPI_MODEL env var. Supports chat and image generation. Supports many models including deepseek, google, openai and more. Docs: https://docs.anyapi.ai/")
 
 	bold.Println("\nProvider: deepseek")
 	fmt.Println("Uses deepseek-reasoner model by default. Requires API key. Recognizes the DEEPSEEK_API_KEY and DEEPSEEK_MODEL environment variables")

--- a/src/helper/helper.go
+++ b/src/helper/helper.go
@@ -915,6 +915,9 @@ func ShowHelpMessage() {
 
 	boldBlue.Println("\nImage generation providers:")
 
+	bold.Println("\nProvider: anyapi")
+	fmt.Println("Requires API key via ANYAPI_API_KEY env var or --key. Supports many models including google/gemini-2.5-flash-image")
+
 	bold.Println("\nProvider: pollinations")
 	fmt.Println("Supported models: flux, turbo")
 

--- a/src/imagegen/anyapi/anyapi.go
+++ b/src/imagegen/anyapi/anyapi.go
@@ -45,6 +45,10 @@ func GenerateImage(prompt string, params structs.ImageParams) string {
 	if apiKey == "" {
 		apiKey = os.Getenv("ANYAPI_API_KEY")
 	}
+	if apiKey == "" {
+		fmt.Fprintln(os.Stderr, "AnyAPI requires an API key. Set ANYAPI_API_KEY env var or use --key")
+		os.Exit(1)
+	}
 
 	requestInfo := ImageRequest{
 		Model:  model,
@@ -92,7 +96,7 @@ func GenerateImage(prompt string, params structs.ImageParams) string {
 		os.Exit(1)
 	}
 
-	if len(result.Data) == 0 {
+	if len(result.Data) == 0 || result.Data[0].B64JSON == "" {
 		fmt.Fprintln(os.Stderr, "No image data in response")
 		os.Exit(1)
 	}

--- a/src/imagegen/anyapi/anyapi.go
+++ b/src/imagegen/anyapi/anyapi.go
@@ -1,0 +1,118 @@
+package anyapi
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	http "github.com/bogdanfinn/fhttp"
+
+	"github.com/aandrew-me/tgpt/v2/src/client"
+	"github.com/aandrew-me/tgpt/v2/src/structs"
+	"github.com/aandrew-me/tgpt/v2/src/utils"
+)
+
+type ImageRequest struct {
+	Model  string `json:"model"`
+	Prompt string `json:"prompt"`
+	N      int    `json:"n,omitempty"`
+}
+
+type ImageResponse struct {
+	Created int `json:"created"`
+	Data    []struct {
+		B64JSON       string `json:"b64_json"`
+		RevisedPrompt string `json:"revised_prompt,omitempty"`
+	} `json:"data"`
+}
+
+func GenerateImage(prompt string, params structs.ImageParams) string {
+	client, err := client.NewClient()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	model := params.ApiModel
+	if model == "" {
+		model = "google/gemini-2.5-flash-image"
+	}
+
+	apiKey := params.ApiKey
+	if apiKey == "" {
+		apiKey = os.Getenv("ANYAPI_API_KEY")
+	}
+
+	requestInfo := ImageRequest{
+		Model:  model,
+		Prompt: prompt,
+		N:      1,
+	}
+
+	jsonRequest, err := json.Marshal(requestInfo)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Failed to build request")
+		os.Exit(1)
+	}
+
+	req, err := http.NewRequest("POST", "https://api.anyapi.ai/v1/images/generations", bytes.NewBuffer(jsonRequest))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Some error has occurred.\nError:", err)
+		os.Exit(1)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	res, err := client.Do(req)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Some error has occurred.\nError:", err)
+		os.Exit(1)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != 200 {
+		body, _ := io.ReadAll(res.Body)
+		fmt.Fprintf(os.Stderr, "Error: %s\n", string(body))
+		os.Exit(1)
+	}
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Failed to read response")
+		os.Exit(1)
+	}
+
+	var result ImageResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		fmt.Fprintln(os.Stderr, "Failed to parse response")
+		os.Exit(1)
+	}
+
+	if len(result.Data) == 0 {
+		fmt.Fprintln(os.Stderr, "No image data in response")
+		os.Exit(1)
+	}
+
+	filepath := params.Out
+	if filepath == "" {
+		randId := utils.RandomString(20)
+		filepath = randId + ".png"
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(result.Data[0].B64JSON)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Failed to decode image data")
+		os.Exit(1)
+	}
+
+	if err := os.WriteFile(filepath, decoded, 0644); err != nil {
+		fmt.Fprintln(os.Stderr, "Failed to save image")
+		os.Exit(1)
+	}
+
+	return filepath
+}

--- a/src/imagegen/imagegen.go
+++ b/src/imagegen/imagegen.go
@@ -2,6 +2,7 @@ package imagegen
 
 import (
 	"fmt"
+	"github.com/aandrew-me/tgpt/v2/src/imagegen/anyapi"
 	"github.com/aandrew-me/tgpt/v2/src/imagegen/arta"
 	pollinations_img "github.com/aandrew-me/tgpt/v2/src/imagegen/pollinations"
 	"github.com/aandrew-me/tgpt/v2/src/structs"
@@ -29,6 +30,18 @@ func GenerateImg(prompt string, params structs.ImageParams, isQuite bool) {
 			bold.Println("Generating image with arta...")
 		}
 		arta.Main(prompt, params, isQuite)
+
+	case "anyapi":
+		if !isQuite {
+			bold.Println("Generating image with anyapi.ai...")
+		}
+		filename := anyapi.GenerateImage(prompt, params)
+		if !isQuite {
+			fmt.Printf("Saved image as %v\n", filename)
+		} else {
+			fmt.Println(filename)
+		}
+
 	default:
 		utils.PrintError("Such a provider doesn't exist")
 

--- a/src/providers/anyapi/anyapi.go
+++ b/src/providers/anyapi/anyapi.go
@@ -24,7 +24,7 @@ func NewRequest(input string, params structs.Params) (*http.Response, error) {
 	client, err := client.NewClient()
 	if err != nil {
 		fmt.Println(err)
-		os.Exit(0)
+		os.Exit(1)
 	}
 
 	model := "openai/gpt-4o-mini"

--- a/src/providers/anyapi/anyapi.go
+++ b/src/providers/anyapi/anyapi.go
@@ -1,0 +1,93 @@
+package anyapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	http "github.com/bogdanfinn/fhttp"
+
+	"github.com/aandrew-me/tgpt/v2/src/client"
+	"github.com/aandrew-me/tgpt/v2/src/structs"
+)
+
+type RequestBody struct {
+	Model    string `json:"model"`
+	Stream   bool   `json:"stream"`
+	Messages []any  `json:"messages"`
+}
+
+func NewRequest(input string, params structs.Params) (*http.Response, error) {
+	client, err := client.NewClient()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(0)
+	}
+
+	model := "openai/gpt-4o-mini"
+	if params.ApiModel != "" {
+		model = params.ApiModel
+	} else if envModel := os.Getenv("ANYAPI_MODEL"); envModel != "" {
+		model = envModel
+	}
+
+	apiKey := params.ApiKey
+	if apiKey == "" {
+		apiKey = os.Getenv("ANYAPI_API_KEY")
+	}
+
+	requestInfo := RequestBody{
+		Model:  model,
+		Stream: true,
+		Messages: []any{
+			structs.DefaultMessage{
+				Content: params.SystemPrompt,
+				Role:    "system",
+			},
+		},
+	}
+
+	if len(params.PrevMessages) > 0 {
+		requestInfo.Messages = append(requestInfo.Messages, params.PrevMessages...)
+	}
+
+	requestInfo.Messages = append(requestInfo.Messages, structs.DefaultMessage{
+		Role:    "user",
+		Content: input,
+	})
+
+	jsonRequest, err := json.Marshal(requestInfo)
+	if err != nil {
+		log.Fatal("Failed to build user request")
+	}
+
+	req, err := http.NewRequest("POST", "https://api.anyapi.ai/v1/chat/completions", bytes.NewBuffer(jsonRequest))
+	if err != nil {
+		log.Fatal("Some error has occured.\nError:", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	return client.Do(req)
+}
+
+func GetMainText(line string) (mainText string) {
+	obj := "{}"
+	if after, ok := strings.CutPrefix(line, "data: "); ok {
+		obj = after
+	}
+
+	var d structs.CommonResponse
+	if err := json.Unmarshal([]byte(obj), &d); err != nil {
+		return ""
+	}
+
+	if len(d.Choices) > 0 {
+		return d.Choices[0].Delta.Content
+	}
+	return ""
+}

--- a/src/providers/anyapi/anyapi.go
+++ b/src/providers/anyapi/anyapi.go
@@ -38,6 +38,10 @@ func NewRequest(input string, params structs.Params) (*http.Response, error) {
 	if apiKey == "" {
 		apiKey = os.Getenv("ANYAPI_API_KEY")
 	}
+	if apiKey == "" {
+		fmt.Fprintln(os.Stderr, "AnyAPI requires an API key. Set ANYAPI_API_KEY env var or use --key")
+		os.Exit(1)
+	}
 
 	requestInfo := RequestBody{
 		Model:  model,

--- a/src/providers/providers.go
+++ b/src/providers/providers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/aandrew-me/tgpt/v2/src/providers/anyapi"
 	"github.com/aandrew-me/tgpt/v2/src/providers/deepseek"
 	"github.com/aandrew-me/tgpt/v2/src/providers/gemini"
 	"github.com/aandrew-me/tgpt/v2/src/providers/groq"
@@ -22,11 +23,13 @@ import (
 )
 
 var availableProviders = []string{
-	"", "deepseek", "isou", "gemini", "groq", "kimi", "koboldai", "minimax", "ollama", "ollamacloud", "opencode", "openai", "pollinations", "powerbrain", "sky",
+	"", "anyapi", "deepseek", "isou", "gemini", "groq", "kimi", "koboldai", "minimax", "ollama", "ollamacloud", "opencode", "openai", "pollinations", "powerbrain", "sky",
 }
 
 func GetMainText(line string, provider string, input string) string {
 	switch provider {
+	case "anyapi":
+		return anyapi.GetMainText(line)
 	case "deepseek":
 		return deepseek.GetMainText(line)
 	case "isou":
@@ -74,6 +77,8 @@ func NewRequest(input string, params structs.Params, extraOptions structs.ExtraO
 	}
 
 	switch params.Provider {
+	case "anyapi":
+		return anyapi.NewRequest(input, params)
 	case "deepseek":
 		return deepseek.NewRequest(input, params)
 	case "gemini":


### PR DESCRIPTION
Adds [AnyAPI](https://docs.anyapi.ai/) as a new provider with both chat and image generation.

## Features
- 100k free anytokens per day
- Chat via OpenAI-compatible endpoint: `/v1/chat/completions`
- Image generation via `/v1/images/generations` (base64 decode)
- Supports many models: deepseek, google/gemini, openai and more
- Env vars: `ANYAPI_API_KEY`, `ANYAPI_MODEL`

## Files
- `src/providers/anyapi/anyapi.go` — chat provider
- `src/imagegen/anyapi/anyapi.go` — image generation
- `src/providers/providers.go` — registered
- `src/imagegen/imagegen.go` — added anyapi case
- `src/helper/helper.go` — help text
- `md/providers.md` — docs

## Verification
- `go build ./...` — passes
- `go vet ./...` — clean
- Live chat test: `./tgpt --provider anyapi "hello"` works
- Image gen: API format verified via curl (key credits exhausted for live test)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AnyAPI as a supported provider for both chat and image generation.
  * Added AnyAPI model selection and API key configuration (via CLI or environment).
  * Enabled streaming-style chat responses and image generation output (auto-generates a PNG filename when none is provided).
* **Documentation**
  * Updated the provider lists and on-screen help to include AnyAPI, including quota/setup notes, supported capabilities (chat + image), and documentation links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->