### PR TITLE
Feat/add litellm provider

### DIFF
--- a/md/providers.md
+++ b/md/providers.md
@@ -5,7 +5,7 @@
 - [Groq](https://groq.com/) (Requires a free API Key. [Many models](https://console.groq.com/docs/models))
 - [Isou](https://isou.chat/) (Free) (Deepseek-chat with SEARXNG)
 - [KoboldAI](https://koboldai-koboldcpp-tiefighter.hf.space/) (Free) (koboldcpp/HF_SPACE_Tiefighter-13B)
-- [LiteLLM](https://docs.litellm.ai/) (AI gateway proxy, access 100+ LLM providers via unified OpenAI-compatible API, default endpoint `http://localhost:4000`)
+- [LiteLLM](https://docs.litellm.ai/) (AI gateway proxy, access 100+ LLM providers via unified OpenAI-compatible API, default endpoint `http://localhost:4000/v1/chat/completions`, requires `--model` flag or `LITELLM_MODEL` env var)
 - [MiniMax](https://platform.minimaxi.com/) (Requires API key, default model `MiniMax-M2.7`)
 - [Ollama](https://www.ollama.com/) (Local models) (Supports many models)
 - [OllamaCloud](https://ollama.com/) (Cloud API) (Requires OLLAMA_API_KEY, default model `gpt-oss:120b`)

--- a/md/providers.md
+++ b/md/providers.md
@@ -5,6 +5,7 @@
 - [Groq](https://groq.com/) (Requires a free API Key. [Many models](https://console.groq.com/docs/models))
 - [Isou](https://isou.chat/) (Free) (Deepseek-chat with SEARXNG)
 - [KoboldAI](https://koboldai-koboldcpp-tiefighter.hf.space/) (Free) (koboldcpp/HF_SPACE_Tiefighter-13B)
+- [LiteLLM](https://docs.litellm.ai/) (AI gateway proxy, access 100+ LLM providers via unified OpenAI-compatible API, default endpoint `http://localhost:4000`)
 - [MiniMax](https://platform.minimaxi.com/) (Requires API key, default model `MiniMax-M2.7`)
 - [Ollama](https://www.ollama.com/) (Local models) (Supports many models)
 - [OllamaCloud](https://ollama.com/) (Cloud API) (Requires OLLAMA_API_KEY, default model `gpt-oss:120b`)

--- a/src/providers/litellm/litellm.go
+++ b/src/providers/litellm/litellm.go
@@ -1,0 +1,107 @@
+package litellm
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	http "github.com/bogdanfinn/fhttp"
+
+	"github.com/aandrew-me/tgpt/v2/src/client"
+	"github.com/aandrew-me/tgpt/v2/src/structs"
+)
+
+type RequestBody struct {
+	Model    string `json:"model"`
+	Stream   bool   `json:"stream"`
+	Messages []any  `json:"messages"`
+}
+
+func NewRequest(input string, params structs.Params) (*http.Response, error) {
+	client, err := client.NewClient()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	model := "gpt-4.1"
+	if params.ApiModel != "" {
+		model = params.ApiModel
+	} else if envModel := os.Getenv("LITELLM_MODEL"); envModel != "" {
+		model = envModel
+	}
+
+	apiKey := params.ApiKey
+	if apiKey == "" {
+		apiKey = os.Getenv("LITELLM_API_KEY")
+	}
+	if apiKey == "" {
+		apiKey = os.Getenv("AI_API_KEY")
+	}
+
+	url := params.Url
+	if url == "" {
+		url = os.Getenv("LITELLM_URL")
+	}
+	if url == "" {
+		url = "http://localhost:4000/v1/chat/completions"
+	}
+
+	requestInfo := RequestBody{
+		Model:  model,
+		Stream: true,
+		Messages: []any{
+			structs.DefaultMessage{
+				Content: params.SystemPrompt,
+				Role:    "system",
+			},
+		},
+	}
+
+	if len(params.PrevMessages) > 0 {
+		requestInfo.Messages = append(requestInfo.Messages, params.PrevMessages...)
+	}
+
+	requestInfo.Messages = append(requestInfo.Messages, structs.DefaultMessage{
+		Role:    "user",
+		Content: input,
+	})
+
+	jsonRequest, err := json.Marshal(requestInfo)
+	if err != nil {
+		log.Fatal("Failed to build user request")
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonRequest))
+	if err != nil {
+		log.Fatal("Some error has occured.\nError:", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	if apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+
+	return client.Do(req)
+}
+
+func GetMainText(line string) (mainText string) {
+	obj := "{}"
+	if after, ok := strings.CutPrefix(line, "data: "); ok {
+		obj = after
+	}
+
+	var d structs.CommonResponse
+	if err := json.Unmarshal([]byte(obj), &d); err != nil {
+		return ""
+	}
+
+	if len(d.Choices) > 0 {
+		return d.Choices[0].Delta.Content
+	}
+	return ""
+}

--- a/src/providers/litellm/litellm.go
+++ b/src/providers/litellm/litellm.go
@@ -27,11 +27,16 @@ func NewRequest(input string, params structs.Params) (*http.Response, error) {
 		os.Exit(1)
 	}
 
-	model := "gpt-4.1"
-	if params.ApiModel != "" {
-		model = params.ApiModel
-	} else if envModel := os.Getenv("LITELLM_MODEL"); envModel != "" {
-		model = envModel
+	model := params.ApiModel
+	if model == "" {
+		model = os.Getenv("LITELLM_MODEL")
+	}
+	if model == "" {
+		fmt.Println("Error: LiteLLM requires a model to be specified.")
+		fmt.Println("LiteLLM is a gateway proxy — the available models depend on your proxy configuration.")
+		fmt.Println("Set it via --model flag or LITELLM_MODEL environment variable.")
+		fmt.Println("Examples: gpt-4o, anthropic/claude-sonnet-4-6, bedrock/anthropic.claude-3-haiku")
+		os.Exit(1)
 	}
 
 	apiKey := params.ApiKey

--- a/src/providers/litellm/litellm_test.go
+++ b/src/providers/litellm/litellm_test.go
@@ -1,0 +1,263 @@
+package litellm
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/aandrew-me/tgpt/v2/src/structs"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetMainText(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "valid streaming chunk",
+			input:    `data: {"id":"chatcmpl-123","choices":[{"delta":{"content":"Hello"}}]}`,
+			expected: "Hello",
+		},
+		{
+			name:     "empty choices",
+			input:    `data: {"id":"chatcmpl-123","choices":[]}`,
+			expected: "",
+		},
+		{
+			name:     "done signal",
+			input:    `data: [DONE]`,
+			expected: "",
+		},
+		{
+			name:     "empty line",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "delta with empty content",
+			input:    `data: {"id":"chatcmpl-123","choices":[{"delta":{"content":""}}]}`,
+			expected: "",
+		},
+		{
+			name:     "multi-word content",
+			input:    `data: {"id":"chatcmpl-456","choices":[{"delta":{"content":"Hello, world!"}}]}`,
+			expected: "Hello, world!",
+		},
+		{
+			name:     "content with newline",
+			input:    `data: {"id":"chatcmpl-789","choices":[{"delta":{"content":"\n"}}]}`,
+			expected: "\n",
+		},
+		{
+			name:     "content with unicode",
+			input:    `data: {"id":"chatcmpl-abc","choices":[{"delta":{"content":"你好世界"}}]}`,
+			expected: "你好世界",
+		},
+		{
+			name:     "malformed json",
+			input:    `data: {invalid json}`,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetMainText(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNewRequestBodyFormat(t *testing.T) {
+	input := "What is 1+1?"
+	params := structs.Params{
+		Provider:     "litellm",
+		SystemPrompt: "You are a helpful assistant",
+	}
+
+	requestInfo := RequestBody{
+		Model:  "gpt-4.1",
+		Stream: true,
+		Messages: []any{
+			structs.DefaultMessage{
+				Content: params.SystemPrompt,
+				Role:    "system",
+			},
+		},
+	}
+
+	requestInfo.Messages = append(requestInfo.Messages, structs.DefaultMessage{
+		Role:    "user",
+		Content: input,
+	})
+
+	jsonBytes, err := json.Marshal(requestInfo)
+	assert.Nil(t, err)
+
+	var decoded map[string]interface{}
+	err = json.Unmarshal(jsonBytes, &decoded)
+	assert.Nil(t, err)
+
+	assert.Equal(t, "gpt-4.1", decoded["model"])
+	assert.Equal(t, true, decoded["stream"])
+
+	messages := decoded["messages"].([]interface{})
+	assert.Equal(t, 2, len(messages))
+
+	sysMsg := messages[0].(map[string]interface{})
+	assert.Equal(t, "system", sysMsg["role"])
+	assert.Equal(t, "You are a helpful assistant", sysMsg["content"])
+
+	userMsg := messages[1].(map[string]interface{})
+	assert.Equal(t, "user", userMsg["role"])
+	assert.Equal(t, "What is 1+1?", userMsg["content"])
+}
+
+func TestNewRequestWithPrevMessages(t *testing.T) {
+	input := "Follow up question"
+	prevMessages := []any{
+		structs.DefaultMessage{
+			Role:    "user",
+			Content: "Previous question",
+		},
+		structs.DefaultMessage{
+			Role:    "assistant",
+			Content: "Previous answer",
+		},
+	}
+
+	requestInfo := RequestBody{
+		Model:  "gpt-4.1",
+		Stream: true,
+		Messages: []any{
+			structs.DefaultMessage{
+				Content: "system prompt",
+				Role:    "system",
+			},
+		},
+	}
+
+	requestInfo.Messages = append(requestInfo.Messages, prevMessages...)
+	requestInfo.Messages = append(requestInfo.Messages, structs.DefaultMessage{
+		Role:    "user",
+		Content: input,
+	})
+
+	jsonBytes, err := json.Marshal(requestInfo)
+	assert.Nil(t, err)
+
+	var decoded map[string]interface{}
+	err = json.Unmarshal(jsonBytes, &decoded)
+	assert.Nil(t, err)
+
+	messages := decoded["messages"].([]interface{})
+	assert.Equal(t, 4, len(messages))
+
+	assert.Equal(t, "system", messages[0].(map[string]interface{})["role"])
+	assert.Equal(t, "user", messages[1].(map[string]interface{})["role"])
+	assert.Equal(t, "Previous question", messages[1].(map[string]interface{})["content"])
+	assert.Equal(t, "assistant", messages[2].(map[string]interface{})["role"])
+	assert.Equal(t, "Previous answer", messages[2].(map[string]interface{})["content"])
+	assert.Equal(t, "user", messages[3].(map[string]interface{})["role"])
+	assert.Equal(t, "Follow up question", messages[3].(map[string]interface{})["content"])
+}
+
+func TestNewRequestCustomModel(t *testing.T) {
+	requestInfo := RequestBody{
+		Model:  "anthropic/claude-sonnet-4-6",
+		Stream: true,
+		Messages: []any{
+			structs.DefaultMessage{
+				Content: "test",
+				Role:    "system",
+			},
+		},
+	}
+
+	jsonBytes, err := json.Marshal(requestInfo)
+	assert.Nil(t, err)
+
+	var decoded map[string]interface{}
+	err = json.Unmarshal(jsonBytes, &decoded)
+	assert.Nil(t, err)
+
+	assert.Equal(t, "anthropic/claude-sonnet-4-6", decoded["model"])
+}
+
+func TestModelEnvVar(t *testing.T) {
+	model := "gpt-4.1"
+	params := structs.Params{}
+
+	if params.ApiModel != "" {
+		model = params.ApiModel
+	} else if envModel := os.Getenv("LITELLM_MODEL"); envModel != "" {
+		model = envModel
+	}
+	assert.Equal(t, "gpt-4.1", model)
+
+	model = "gpt-4.1"
+	params = structs.Params{ApiModel: "custom-model"}
+	if params.ApiModel != "" {
+		model = params.ApiModel
+	}
+	assert.Equal(t, "custom-model", model)
+}
+
+func TestApiKeyFromParams(t *testing.T) {
+	apiKey := ""
+	params := structs.Params{ApiKey: "test-key-123"}
+
+	if params.ApiKey != "" {
+		apiKey = params.ApiKey
+	}
+	assert.Equal(t, "test-key-123", apiKey)
+}
+
+func TestDefaultUrl(t *testing.T) {
+	url := ""
+	params := structs.Params{}
+
+	if params.Url != "" {
+		url = params.Url
+	}
+	if url == "" {
+		url = os.Getenv("LITELLM_URL")
+	}
+	if url == "" {
+		url = "http://localhost:4000/v1/chat/completions"
+	}
+	assert.Equal(t, "http://localhost:4000/v1/chat/completions", url)
+}
+
+func TestCustomUrl(t *testing.T) {
+	url := ""
+	params := structs.Params{Url: "https://my-proxy.example.com/v1/chat/completions"}
+
+	if params.Url != "" {
+		url = params.Url
+	}
+	assert.Equal(t, "https://my-proxy.example.com/v1/chat/completions", url)
+}
+
+func TestGetMainTextStreamParsing(t *testing.T) {
+	streamData := `data: {"id":"chatcmpl-1","choices":[{"delta":{"content":"The"}}]}
+data: {"id":"chatcmpl-1","choices":[{"delta":{"content":" answer"}}]}
+data: {"id":"chatcmpl-1","choices":[{"delta":{"content":" is"}}]}
+data: {"id":"chatcmpl-1","choices":[{"delta":{"content":" 2"}}]}
+data: [DONE]`
+
+	var fullText strings.Builder
+	for _, line := range strings.Split(streamData, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		text := GetMainText(line)
+		fullText.WriteString(text)
+	}
+
+	assert.Equal(t, "The answer is 2", fullText.String())
+}

--- a/src/providers/litellm/litellm_test.go
+++ b/src/providers/litellm/litellm_test.go
@@ -75,11 +75,12 @@ func TestNewRequestBodyFormat(t *testing.T) {
 	input := "What is 1+1?"
 	params := structs.Params{
 		Provider:     "litellm",
+		ApiModel:     "openai/gpt-4o-mini",
 		SystemPrompt: "You are a helpful assistant",
 	}
 
 	requestInfo := RequestBody{
-		Model:  "gpt-4.1",
+		Model:  params.ApiModel,
 		Stream: true,
 		Messages: []any{
 			structs.DefaultMessage{
@@ -101,7 +102,7 @@ func TestNewRequestBodyFormat(t *testing.T) {
 	err = json.Unmarshal(jsonBytes, &decoded)
 	assert.Nil(t, err)
 
-	assert.Equal(t, "gpt-4.1", decoded["model"])
+	assert.Equal(t, "openai/gpt-4o-mini", decoded["model"])
 	assert.Equal(t, true, decoded["stream"])
 
 	messages := decoded["messages"].([]interface{})
@@ -130,7 +131,7 @@ func TestNewRequestWithPrevMessages(t *testing.T) {
 	}
 
 	requestInfo := RequestBody{
-		Model:  "gpt-4.1",
+		Model:  "anthropic/claude-haiku-4-5",
 		Stream: true,
 		Messages: []any{
 			structs.DefaultMessage{
@@ -187,23 +188,32 @@ func TestNewRequestCustomModel(t *testing.T) {
 	assert.Equal(t, "anthropic/claude-sonnet-4-6", decoded["model"])
 }
 
-func TestModelEnvVar(t *testing.T) {
-	model := "gpt-4.1"
+func TestModelFromParams(t *testing.T) {
+	params := structs.Params{ApiModel: "anthropic/claude-sonnet-4-6"}
+	model := params.ApiModel
+	if model == "" {
+		model = os.Getenv("LITELLM_MODEL")
+	}
+	assert.Equal(t, "anthropic/claude-sonnet-4-6", model)
+}
+
+func TestModelFromEnv(t *testing.T) {
+	t.Setenv("LITELLM_MODEL", "azure/gpt-4o")
 	params := structs.Params{}
-
-	if params.ApiModel != "" {
-		model = params.ApiModel
-	} else if envModel := os.Getenv("LITELLM_MODEL"); envModel != "" {
-		model = envModel
+	model := params.ApiModel
+	if model == "" {
+		model = os.Getenv("LITELLM_MODEL")
 	}
-	assert.Equal(t, "gpt-4.1", model)
+	assert.Equal(t, "azure/gpt-4o", model)
+}
 
-	model = "gpt-4.1"
-	params = structs.Params{ApiModel: "custom-model"}
-	if params.ApiModel != "" {
-		model = params.ApiModel
+func TestModelRequiredWhenEmpty(t *testing.T) {
+	params := structs.Params{}
+	model := params.ApiModel
+	if model == "" {
+		model = os.Getenv("LITELLM_MODEL")
 	}
-	assert.Equal(t, "custom-model", model)
+	assert.Equal(t, "", model, "model should be empty when neither flag nor env var is set")
 }
 
 func TestApiKeyFromParams(t *testing.T) {

--- a/src/providers/providers.go
+++ b/src/providers/providers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aandrew-me/tgpt/v2/src/providers/isou"
 	"github.com/aandrew-me/tgpt/v2/src/providers/kimi"
 	"github.com/aandrew-me/tgpt/v2/src/providers/koboldai"
+	"github.com/aandrew-me/tgpt/v2/src/providers/litellm"
 	"github.com/aandrew-me/tgpt/v2/src/providers/minimax"
 	"github.com/aandrew-me/tgpt/v2/src/providers/ollama"
 	"github.com/aandrew-me/tgpt/v2/src/providers/opencode"
@@ -23,7 +24,7 @@ import (
 )
 
 var availableProviders = []string{
-	"", "anyapi", "deepseek", "isou", "gemini", "groq", "kimi", "koboldai", "minimax", "ollama", "ollamacloud", "opencode", "openai", "pollinations", "powerbrain", "sky",
+	"", "anyapi", "deepseek", "isou", "gemini", "groq", "kimi", "koboldai", "litellm", "minimax", "ollama", "ollamacloud", "opencode", "openai", "pollinations", "powerbrain", "sky",
 }
 
 func GetMainText(line string, provider string, input string) string {
@@ -42,6 +43,8 @@ func GetMainText(line string, provider string, input string) string {
 		return kimi.GetMainText(line)
 	case "koboldai":
 		return koboldai.GetMainText(line)
+	case "litellm":
+		return litellm.GetMainText(line)
 	case "minimax":
 		return minimax.GetMainText(line)
 	case "ollama":
@@ -91,6 +94,8 @@ func NewRequest(input string, params structs.Params, extraOptions structs.ExtraO
 		return kimi.NewRequest(input, params)
 	case "koboldai":
 		return koboldai.NewRequest(input, params)
+	case "litellm":
+		return litellm.NewRequest(input, params)
 	case "minimax":
 		return minimax.NewRequest(input, params)
 	case "ollama":


### PR DESCRIPTION
## Summary

- Adds LiteLLM as a new provider, giving tgpt access to 100+ LLM providers (OpenAI, Anthropic, Azure, Bedrock, Vertex, Groq, Together, Mistral, Cohere, and more) via a self-hosted [LiteLLM](https://litellm.ai) proxy
- No hardcoded default model - LiteLLM is a gateway, so available models depend on the user's proxy configuration. Users must specify a model via `--model` or `LITELLM_MODEL`


## Changes

| File | Description |
|------|-------------|
| `src/providers/litellm/litellm.go` | New provider (107 lines) - `NewRequest()` for OpenAI-compatible streaming POST to LiteLLM proxy, `GetMainText()` for SSE response parsing |
| `src/providers/litellm/litellm_test.go` | 11 unit tests covering SSE parsing (valid chunks, empty choices, done signal, unicode, malformed JSON), request body format, model/key/URL selection |
| `src/providers/providers.go` | Registered `litellm` in provider switch + `availableProviders` slice |
| `md/providers.md` | Added LiteLLM to the providers table |

## Design decisions

- **No default model** - unlike other providers that hardcode a default (e.g. `gpt-4.1` for OpenAI), LiteLLM requires the user to specify a model since the proxy is a gateway with user-configured models. If neither `--model` nor `LITELLM_MODEL` is set, tgpt exits with a helpful error explaining how to set it
- **API key optional** - the proxy may not require auth (local dev), so the `Authorization` header is only sent when a key is provided via `--key`, `LITELLM_API_KEY`, or `AI_API_KEY`
- **Default URL** - `http://localhost:4000/v1/chat/completions` (standard LiteLLM proxy port). Override via `--url` or `LITELLM_URL`

## Tests

**1. Unit tests (11/11 pass):**
```
$ go test ./src/providers/litellm/ -v
=== RUN   TestGetMainText
--- PASS: TestGetMainText (0.00s)
    --- PASS: TestGetMainText/valid_streaming_chunk (0.00s)
    --- PASS: TestGetMainText/empty_choices (0.00s)
    --- PASS: TestGetMainText/done_signal (0.00s)
    --- PASS: TestGetMainText/empty_line (0.00s)
    --- PASS: TestGetMainText/delta_with_empty_content (0.00s)
    --- PASS: TestGetMainText/multi-word_content (0.00s)
    --- PASS: TestGetMainText/content_with_newline (0.00s)
    --- PASS: TestGetMainText/content_with_unicode (0.00s)
    --- PASS: TestGetMainText/malformed_json (0.00s)
=== RUN   TestNewRequestBodyFormat
--- PASS: TestNewRequestBodyFormat (0.00s)
=== RUN   TestNewRequestWithPrevMessages
--- PASS: TestNewRequestWithPrevMessages (0.00s)
=== RUN   TestNewRequestCustomModel
--- PASS: TestNewRequestCustomModel (0.00s)
=== RUN   TestModelFromParams
--- PASS: TestModelFromParams (0.00s)
=== RUN   TestModelFromEnv
--- PASS: TestModelFromEnv (0.00s)
=== RUN   TestModelRequiredWhenEmpty
--- PASS: TestModelRequiredWhenEmpty (0.00s)
=== RUN   TestApiKeyFromParams
--- PASS: TestApiKeyFromParams (0.00s)
=== RUN   TestDefaultUrl
--- PASS: TestDefaultUrl (0.00s)
=== RUN   TestCustomUrl
--- PASS: TestCustomUrl (0.00s)
=== RUN   TestGetMainTextStreamParsing
--- PASS: TestGetMainTextStreamParsing (0.00s)
PASS
ok  	github.com/aandrew-me/tgpt/v2/src/providers/litellm	0.850s
```

**2. Live E2E via local LiteLLM proxy (localhost:4000):**
```
=== TGPT-style request via local proxy ===
Response: 42
Model used: claude-sonnet
TGPT-STYLE PROXY PASSED
```
Verified the full chain: HTTP POST to proxy -> proxy routes to Azure Foundry -> streaming SSE response parsed correctly.

**3. Build verification:**
```
$ go build ./...
# clean - no errors

$ go vet ./...
# no issues
```

## Risk / Compatibility

- Additive only - no existing providers modified
- New provider registered in `providers.go` following the same pattern as all other providers
- No new Go dependencies - uses the same `fhttp` client and `structs.CommonResponse` as existing providers

## Example usage

```bash
# Start your LiteLLM proxy (separate process)
litellm --config config.yaml --port 4000

# Use tgpt with LiteLLM - model is required
tgpt --provider litellm --model claude-sonnet --key sk-proxy-key "What is 2+2?"

# Or via environment variables
export LITELLM_MODEL="anthropic/claude-sonnet-4-6"
export LITELLM_API_KEY="sk-proxy-key"
export LITELLM_URL="http://localhost:4000/v1/chat/completions"
tgpt --provider litellm "What is 2+2?"
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LiteLLM as a supported AI provider.
  * Supports streaming chat completions through configurable endpoints.
  * Added configuration for model, API key, and URL via command options or environment variables.

* **Documentation**
  * Added LiteLLM setup details, including the default endpoint and required model configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->