### PR TITLE
Exa search provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ CLAUDE.md
 # Tools directory - development/testing utilities
 tools/
 .opencode/
+config.conf
 config.txt
 *.jpg

--- a/config_test.go
+++ b/config_test.go
@@ -9,7 +9,7 @@ import (
 func TestLoadConfig(t *testing.T) {
 	// Create a temp config file
 	tmpDir := t.TempDir()
-	configPath := filepath.Join(tmpDir, "config.txt")
+	configPath := filepath.Join(tmpDir, "config.conf")
 	content := `# This is a comment
 				AI_PROVIDER=deepseek
 				TEST_KEY_FROM_CONFIG=hello

--- a/main.go
+++ b/main.go
@@ -97,6 +97,7 @@ func main() {
 	var imgNegative *string
 	var imgCount *string
 	var imgRatio *string
+	var searchProvider *string
 
 	// Load config file
 	var configPath string
@@ -147,6 +148,7 @@ func main() {
 
 	logFile = flag.String("log", "", "Filepath to log conversation to.")
 	rotateProviders = flag.String("rotate", "", "Comma-separated fallback providers (Env: AI_ROTATE_PROVIDERS)")
+	searchProvider = flag.String("search-provider", "", "Search provider: exa or google (Env: SEARCH_PROVIDER)")
 	shouldExecuteCommand = flag.Bool(("y"), false, "Instantly execute the shell command")
 
 	isQuiet := flag.Bool("q", false, "Gives response back without loading animation")
@@ -219,6 +221,14 @@ func main() {
 	rotateStr := *rotateProviders
 	if !rotateProvidersSet && rotateStr == "" {
 		rotateStr = os.Getenv("AI_ROTATE_PROVIDERS")
+	}
+
+	finalSearchProvider := *searchProvider
+	if finalSearchProvider == "" {
+		finalSearchProvider = os.Getenv("SEARCH_PROVIDER")
+	}
+	if finalSearchProvider == "" {
+		finalSearchProvider = "exa"
 	}
 
 	main_params := structs.Params{
@@ -654,8 +664,9 @@ func main() {
 				}
 
 				extraOptions := structs.ExtraOptions{
-					IsFind:  true,
-					Verbose: *isVerbose,
+					IsFind:         true,
+					Verbose:        *isVerbose,
+					SearchProvider: finalSearchProvider,
 				}
 
 				helper.SearchQuery(trimmedPrompt, main_params, extraOptions, *isQuiet, *logFile)
@@ -676,6 +687,7 @@ func main() {
 				IsInteractiveFind: true,
 				IsFind:            true,
 				Verbose:           *isVerbose,
+				SearchProvider:    finalSearchProvider,
 			}
 
 			// Create a prompt-compatible input reader function for confirmations

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -36,10 +37,10 @@ func loadConfig(configPath string) {
 
 	if configPath == "" {
 		defaultPaths := []string{
-			"config.txt",
+			"config.conf",
 		}
 		if homeDir, err := os.UserHomeDir(); err == nil {
-			defaultPaths = append(defaultPaths, filepath.Join(homeDir, ".config", "tgpt", "config.txt"))
+			defaultPaths = append(defaultPaths, filepath.Join(homeDir, ".config", "tgpt", "config.conf"))
 		}
 		for _, p := range defaultPaths {
 			if _, err := os.Stat(p); err == nil {
@@ -661,6 +662,20 @@ func main() {
 					utils.PrintError("You need to provide some text")
 					utils.PrintError(`Example: tgpt -f "What is the latest news about AI?"`)
 					return
+				}
+
+				// Validate search provider
+				supportedSearchProviders := []string{"google", "exa", ""}
+
+				searchProviderIsValid := false
+				for _, provider := range supportedSearchProviders {
+					if finalSearchProvider == provider {
+						searchProviderIsValid = true
+					}
+				}
+
+				if !searchProviderIsValid {
+					log.Fatal("Search provider is not valid")
 				}
 
 				extraOptions := structs.ExtraOptions{

--- a/src/helper/helper.go
+++ b/src/helper/helper.go
@@ -837,6 +837,7 @@ func ShowHelpMessage() {
 	fmt.Printf("%-50v Generate images from text\n", "-img, --image")
 	fmt.Printf("%-50v Set Provider. Detailed information has been provided below. (Env: AI_PROVIDER for chat and IMG_PROVIDER for image gen.)\n", "--provider")
 	fmt.Printf("%-50v Find information using web search \n", "-f, --find")
+	fmt.Printf("%-50v Search provider for web search: exa (default) or google (Env: SEARCH_PROVIDER).\n%-50v Exa works without api key with rate limits and supports EXA_API_KEY env variable.\n%-50v google requires TGPT_GOOGLE_API_KEY and TGPT_GOOGLE_SEARCH_ENGINE_ID env variables.\n%-50s Check SEARCH_SETUP.md for google: https://github.com/aandrew-me/tgpt/blob/main/SEARCH_SETUP.md\n", "--search-provider", "", "", "")
 
 	boldBlue.Println("\nSome additional options can be set. However not all options are supported by all providers. Not supported options will just be ignored.")
 	fmt.Printf("%-50v Set Model\n", "--model")
@@ -953,7 +954,7 @@ func SearchQuery(input string, params structs.Params, extraOptions structs.Extra
 
 	// For one-shot find mode (-f), skip confirmation. For interactive find mode (-if), show confirmation
 	skipConfirmation := extraOptions.IsFind && !extraOptions.IsInteractiveFind
-	searchResults, err := search.ProcessSearchWithConfirmation(input, params, extraOptions.Verbose, skipConfirmation, isQuiet, nil)
+	searchResults, err := search.ProcessSearchWithConfirmation(input, params, extraOptions.Verbose, skipConfirmation, isQuiet, nil, extraOptions.SearchProvider)
 	if err != nil {
 		fmt.Printf("Search failed: %v\n", err)
 		return
@@ -974,7 +975,9 @@ func SearchQuery(input string, params structs.Params, extraOptions structs.Extra
 		IsGetSilent: isQuiet,
 	}
 
-	response, _ := MakeRequestAndGetData(searchResults, params, searchOptions)
+    queryWithContext := fmt.Sprintf("Here is the output of the search results: %s\n\nBased on these search results, answer the user's question: %s", searchResults, input)
+
+	response, _ := MakeRequestAndGetData(queryWithContext, params, searchOptions)
 
 	if len(logFile) > 0 {
 		utils.LogToFile(response, "SEARCH_RESPONSE", logFile)
@@ -1037,7 +1040,7 @@ func InteractiveFindSession(params structs.Params, extraOptions structs.ExtraOpt
 				fmt.Printf("DEBUG: Search intent detected: '%s'\n", searchQuery)
 			}
 
-			searchResults, err := search.ProcessSearchWithConfirmation(searchQuery, params, extraOptions.Verbose, false, false, inputReader)
+			searchResults, err := search.ProcessSearchWithConfirmation(searchQuery, params, extraOptions.Verbose, false, false, inputReader, extraOptions.SearchProvider)
 			if err != nil {
 				fmt.Printf("Search failed: %v\n", err)
 				return

--- a/src/helper/helper.go
+++ b/src/helper/helper.go
@@ -925,7 +925,7 @@ func ShowHelpMessage() {
 	fmt.Println("Supported models: flux, turbo")
 
 	boldBlue.Println("\nConfiguration file")
-	fmt.Println("You can create a configuration file, ~/.config/tgpt/config.txt or in the directory where the tgpt binary is located. The configuration file supports all the environment variables supported by tgpt.")
+	fmt.Println(`You can create a configuration file - config.conf in ~/.config/tgpt (%USERPROFILE%\.config\tgpt on Windows) or in current directory (has higher priority). The configuration file supports all the environment variables supported by tgpt.`)
 	boldBlue.Println("\nExample config file:")
 	codeText.Println("POLLINATIONS_API_KEY=sk_xxxxx")
 	codeText.Println("ANYAPI_API_KEY=sk_xxxxxxxx")

--- a/src/search/search.go
+++ b/src/search/search.go
@@ -76,7 +76,12 @@ type GoogleSearchResponse struct {
 	} `json:"items"`
 }
 
-func PerformExaMCPSearch(userQuery string, verbose bool) (string, error) {
+func PerformExaMCPSearch(params SearchParams, verbose bool) (string, error) {
+	userQuery := params.Query
+	numResults := params.NumResults
+	if numResults <= 0 {
+		numResults = 5
+	}
 	apiKey := os.Getenv("EXA_API_KEY")
 
 	mcpEndpoint := "https://mcp.exa.ai/mcp"
@@ -94,8 +99,8 @@ func PerformExaMCPSearch(userQuery string, verbose bool) (string, error) {
 			"name": "web_search_exa",
 			"arguments": map[string]interface{}{
 				"query":      userQuery,
-				"numResults": 3,
-				"livecrawl": "fallback",
+				"numResults": numResults,
+				"livecrawl":  "fallback",
 			},
 		},
 	}
@@ -243,8 +248,6 @@ func PerformSearch(userQuery string, verbose bool) (string, error) {
 	// Format results for AI synthesis
 	return formatResultsForAI(results, userQuery), nil
 }
-
-// Perform search with exa mcp server
 
 // googleSearch performs the actual Google Custom Search API call
 func googleSearch(params SearchParams, apiKey, searchEngineID string, verbose bool) ([]SearchResult, error) {

--- a/src/search/search.go
+++ b/src/search/search.go
@@ -2,6 +2,7 @@ package search
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -29,6 +30,28 @@ const (
 	maxConcurrentExtractions = 5                // Maximum concurrent content extractions
 )
 
+type MCPResponse struct {
+	JSONRPC string     `json:"jsonrpc"`
+	ID      int        `json:"id"`
+	Result  *MCPResult `json:"result,omitempty"`
+	Error   *MCPError  `json:"error,omitempty"`
+}
+
+type MCPError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type MCPResult struct {
+	Content []MCPContent `json:"content"`
+	IsError bool         `json:"isError,omitempty"`
+}
+
+type MCPContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
 // SearchParams represents the parameters extracted by AI for search
 type SearchParams struct {
 	Query      string `json:"query"`
@@ -53,6 +76,128 @@ type GoogleSearchResponse struct {
 	} `json:"items"`
 }
 
+func PerformExaMCPSearch(userQuery string, verbose bool) (string, error) {
+	apiKey := os.Getenv("EXA_API_KEY")
+
+	mcpEndpoint := "https://mcp.exa.ai/mcp"
+
+	if verbose {
+		fmt.Printf("[Exa MCP] Sending SSE search request: %q to %s\n", userQuery, mcpEndpoint)
+	}
+
+	// 1. Build JSON-RPC payload
+	payload := map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/call",
+		"params": map[string]interface{}{
+			"name": "web_search_exa",
+			"arguments": map[string]interface{}{
+				"query":      userQuery,
+				"numResults": 3,
+				"livecrawl": "fallback",
+			},
+		},
+	}
+
+	reqBody, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal JSON-RPC request: %w", err)
+	}
+
+	// 2. Prepare Request with Event-Stream headers
+	req, err := http.NewRequest("POST", mcpEndpoint, bytes.NewBuffer(reqBody))
+	if err != nil {
+		return "", fmt.Errorf("failed to build request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("Cache-Control", "no-cache")
+	req.Header.Set("Connection", "keep-alive")
+
+	if apiKey != "" {
+		req.Header.Set("x-api-key", apiKey)
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+
+	httpClient, err := client.NewClient()
+	if err != nil {
+		return "", fmt.Errorf("failed to create HTTP client: %w", err)
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("server error HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	// 3. Process the Event Stream
+	reader := bufio.NewReaderSize(resp.Body, 1*1024*1024) // 1 MB buffer
+	var rawDataPayload []byte
+
+	for {
+		line, err := reader.ReadString('\n')
+		line = strings.TrimSpace(line)
+
+		if strings.HasPrefix(line, "data:") {
+			dataStr := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+			rawDataPayload = []byte(dataStr)
+			break // Got our JSON-RPC result payload, exit streaming loop
+		}
+
+		if err != nil {
+			if err == io.EOF && len(rawDataPayload) == 0 {
+				return "", fmt.Errorf("stream ended before receiving 'data:' event")
+			}
+			if err != io.EOF {
+				return "", fmt.Errorf("error reading event stream: %w", err)
+			}
+			break
+		}
+	}
+
+	if len(rawDataPayload) == 0 {
+		return "", fmt.Errorf("empty data payload received from event-stream")
+	}
+
+	// 4. Parse the extracted JSON-RPC payload
+	var mcpResp MCPResponse
+	if err := json.Unmarshal(rawDataPayload, &mcpResp); err != nil {
+		return "", fmt.Errorf("failed to unmarshal SSE JSON payload (%d bytes): %w", len(rawDataPayload), err)
+	}
+
+	if mcpResp.Error != nil {
+		return "", fmt.Errorf("MCP RPC Error [%d]: %s", mcpResp.Error.Code, mcpResp.Error.Message)
+	}
+
+	if mcpResp.Result == nil || len(mcpResp.Result.Content) == 0 {
+		return "No search results returned.", nil
+	}
+
+	if mcpResp.Result.IsError {
+		return "", fmt.Errorf("MCP Tool execution error: %s", mcpResp.Result.Content[0].Text)
+	}
+
+	// 5. Aggregate and return content
+	var builder strings.Builder
+	for i, item := range mcpResp.Result.Content {
+		if item.Type == "text" {
+			if verbose {
+				fmt.Printf("[Exa MCP] Received content block %d (%d bytes)\n", i+1, len(item.Text))
+			}
+			builder.WriteString(item.Text)
+			builder.WriteString("\n\n")
+		}
+	}
+
+	return strings.TrimSpace(builder.String()), nil
+}
+
 // PerformSearch executes the complete search workflow
 func PerformSearch(userQuery string, verbose bool) (string, error) {
 	// Get API credentials from environment
@@ -67,7 +212,7 @@ func PerformSearch(userQuery string, verbose bool) (string, error) {
 	// For now, we'll use simple defaults
 	params := SearchParams{
 		Query:      userQuery,
-		NumResults: 3,
+		NumResults: 5,
 	}
 
 	// Perform Google search
@@ -98,6 +243,8 @@ func PerformSearch(userQuery string, verbose bool) (string, error) {
 	// Format results for AI synthesis
 	return formatResultsForAI(results, userQuery), nil
 }
+
+// Perform search with exa mcp server
 
 // googleSearch performs the actual Google Custom Search API call
 func googleSearch(params SearchParams, apiKey, searchEngineID string, verbose bool) ([]SearchResult, error) {
@@ -402,7 +549,7 @@ func ConfirmSearchExecution(params SearchParams, autoConfirm bool, isQuiet bool,
 
 // ProcessSearchWithConfirmation handles the full search flow with optimization and confirmation
 // inputReader is an optional function to get user input for confirmation. If nil, uses default bufio.NewReader(os.Stdin)
-func ProcessSearchWithConfirmation(userInput string, aiParams structs.Params, verbose bool, skipConfirmation bool, isQuiet bool, inputReader func() (string, error)) (string, error) {
+func ProcessSearchWithConfirmation(userInput string, aiParams structs.Params, verbose bool, skipConfirmation bool, isQuiet bool, inputReader func() (string, error), searchProvider string) (string, error) {
 	if verbose {
 		fmt.Printf("DEBUG: Starting search optimization for: '%s'\n", userInput)
 	}
@@ -418,13 +565,22 @@ func ProcessSearchWithConfirmation(userInput string, aiParams structs.Params, ve
 			searchParams.Query, searchParams.NumResults, searchParams.SiteFilter)
 	}
 
-	// Ask for user confirmation (or auto-confirm for one-shot mode)
-	if !ConfirmSearchExecution(searchParams, skipConfirmation, isQuiet, inputReader) {
-		return "Search cancelled by user.", nil
+	// Ask for user confirmation unless skipConfirmation is enabled
+	if skipConfirmation {
+		if verbose && !isQuiet {
+			fmt.Printf("DEBUG: skipConfirmation enabled, bypassing confirmation prompt\n")
+		}
+	} else {
+		if !ConfirmSearchExecution(searchParams, false, isQuiet, inputReader) {
+			return "Search cancelled by user.", nil
+		}
 	}
 
-	// Proceed with search using the optimized parameters
-	return PerformSearchWithParams(searchParams, verbose)
+	if searchProvider == "google" {
+		return PerformSearchWithParams(searchParams, verbose)
+	}
+
+	return PerformExaMCPSearch(searchParams.Query, verbose)
 }
 
 // PerformSearchWithParams executes search with pre-built SearchParams

--- a/src/structs/structs.go
+++ b/src/structs/structs.go
@@ -24,9 +24,10 @@ type ExtraOptions struct {
 	IsInteractive      bool
 	IsInteractiveShell bool
 	AutoExec           bool
-	IsFind             bool // IsFind enable web search functionality
-	IsInteractiveFind  bool // IsInteractiveFind enable interactive web search mode
-	Verbose            bool // Verbose enable detailed search output
+	IsFind             bool   // IsFind enable web search functionality
+	IsInteractiveFind  bool   // IsInteractiveFind enable interactive web search mode
+	Verbose            bool   // Verbose enable detailed search output
+	SearchProvider     string // Search provider: "exa" (default) or "google"
 }
 
 type CommonResponse struct {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable web search provider selection via `--search-provider` (Exa default, Google alternative).
  * Enabled Exa-powered searching for both one-shot and interactive workflows.
  * Increased the default number of Google results to five.
* **Bug Fixes**
  * Follow-up responses now include the original question together with search results.
* **Documentation**
  * Updated CLI help and configuration guidance to reference `config.conf` and provider requirements.
* **Chores**
  * Standardized default config filename to `config.conf`, updated related ignore/test usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->