### PR TITLE
fix: avoid recording interactive 4xx responses

### DIFF
--- a/src/helper/helper.go
+++ b/src/helper/helper.go
@@ -219,7 +219,10 @@ func (f *interactiveFormatter) writeText(text string) {
 
 
 func GetData(input string, params structs.Params, extraOptions structs.ExtraOptions) ([]interface{}, string) {
-	responseTxt, _ := MakeRequestAndGetData(input, params, extraOptions)
+	responseTxt, err := MakeRequestAndGetData(input, params, extraOptions)
+	if err != nil {
+		return nil, ""
+	}
 
 	if !extraOptions.IsGetSilent {
 		fmt.Print("\n\n")
@@ -707,10 +710,10 @@ func MakeRequestAndGetData(input string, params structs.Params, extraOptions str
 			}
 			respBody, _ := io.ReadAll(resp.Body)
 			resp.Body.Close()
-			fmt.Println("Some error has occurred, try again")
-			fmt.Println(string(respBody))
+			fmt.Fprintln(os.Stderr, "Some error has occurred, try again")
+			fmt.Fprintln(os.Stderr, string(respBody))
 
-			return "", nil
+			return "", fmt.Errorf("provider %s returned status %d", provider, code)
 		}
 
 		stopSpin.Store(true)

--- a/src/helper/helper_test.go
+++ b/src/helper/helper_test.go
@@ -1,12 +1,15 @@
 package helper
 
 import (
+	stdhttp "net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/aandrew-me/tgpt/v2/src/structs"
 	http "github.com/bogdanfinn/fhttp"
 )
 
@@ -97,4 +100,33 @@ func TestHandleStatus400ExitCode(t *testing.T) {
 	}
 }
 
+func TestInteractiveStatusErrorDoesNotAppendAssistantMessage(t *testing.T) {
+	server := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		w.WriteHeader(stdhttp.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":"rate limited"}`))
+	}))
+	defer server.Close()
 
+	params := structs.Params{
+		Provider: "openai",
+		Url:      server.URL,
+	}
+	extraOptions := structs.ExtraOptions{
+		IsInteractive: true,
+		IsGetSilent:   true,
+	}
+
+	if response, err := MakeRequestAndGetData("hello", params, extraOptions); err == nil {
+		t.Fatal("expected interactive 4xx response to return an error")
+	} else if response != "" {
+		t.Fatalf("expected empty response text on error, got %q", response)
+	}
+
+	messages, response := GetData("hello", params, extraOptions)
+	if response != "" {
+		t.Fatalf("expected empty response text from GetData on error, got %q", response)
+	}
+	if len(messages) != 0 {
+		t.Fatalf("expected no conversation history entries on interactive 4xx, got %#v", messages)
+	}
+}


### PR DESCRIPTION
Fixes #445.

## Summary
- Return an error when the final provider returns a 4xx/5xx in interactive modes instead of treating it as an empty successful response.
- Have `GetData` skip conversation-history entries when the request failed, avoiding empty assistant messages in `PrevMessages`.
- Print the interactive status error details to stderr.

## Tests
- `go test -vet=off ./src/helper -run 'TestInteractiveStatusErrorDoesNotAppendAssistantMessage|TestHandleStatus400' -count=1`
- `go test -vet=off ./... -count=1`

Note: `go test ./... -count=1` currently stops in vet on an existing `%USERPROFILE%` string in `src/helper/helper.go`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of failed requests by returning clear errors when providers respond with HTTP errors.
  * Prevented failed interactive requests from adding empty assistant messages to conversation history.
  * Error details are now reported through standard error output for non-interactive failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->