### PR TITLE
fix: remove empty string from AvailableProviders, handle explicitly in NewRequest

### DIFF
--- a/src/providers/providers.go
+++ b/src/providers/providers.go
@@ -22,7 +22,7 @@ import (
 )
 
 var AvailableProviders = []string{
-	"", "anyapi", "deepseek", "isou", "gemini", "groq", "koboldai", "litellm", "minimax", "ollama", "ollamacloud", "opencode", "openai", "pollinations", "powerbrain",
+	"anyapi", "deepseek", "isou", "gemini", "groq", "koboldai", "litellm", "minimax", "ollama", "ollamacloud", "opencode", "openai", "pollinations", "powerbrain",
 }
 
 func IsValidProvider(name string) bool {
@@ -70,12 +70,16 @@ func GetMainText(line string, provider string, input string) string {
 }
 
 func NewRequest(input string, params structs.Params, extraOptions structs.ExtraOptions) (*http.Response, error) {
-	if !IsValidProvider(params.Provider) {
+	provider := params.Provider
+	if provider == "" {
+		provider = "opencode"
+	}
+	if !IsValidProvider(provider) {
 		fmt.Fprintln(os.Stderr, "Invalid provider")
 		os.Exit(1)
 	}
 
-	switch params.Provider {
+	switch provider {
 	case "anyapi":
 		return anyapi.NewRequest(input, params)
 	case "deepseek":


### PR DESCRIPTION
## Description

Removes the `""` entry from `AvailableProviders` so that `IsValidProvider("")` returns `false` as expected, eliminating a confusing edge case in validation logic.

## Changes

1. **`AvailableProviders`** — removed `""` from the list
2. **`NewRequest`** — added explicit handling: if `params.Provider` is empty, it defaults to `"opencode"` before validation and the switch statement

## Why

- Previously, `IsValidProvider("")` returned `true` because `""` was a valid entry, which is misleading for code reviewers and could mask bugs
- The default behavior (no `--provider` flag → `""` → opencode) is preserved through the explicit check in `NewRequest`
- `providersForRotation` already filters out empty strings (line 819-820), so no impact on rotation

## Related Issue
Closes #449

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Requests without a specified provider now default to OpenCode.
  * Provider validation is more consistent and no longer treats an empty provider name as valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->