### PR TITLE
fix: remove dead resp == nil check in rotation loop

### DIFF
--- a/src/helper/helper.go
+++ b/src/helper/helper.go
@@ -689,11 +689,6 @@ func MakeRequestAndGetData(input string, params structs.Params, extraOptions str
 			printConnectionErrorMsg(err)
 		}
 
-		if resp == nil {
-			stopSpin.Store(true)
-			continue
-		}
-
 		code := resp.StatusCode
 		hasMore := i < len(providersToTry)-1
 


### PR DESCRIPTION
## Description

Removes the `if resp == nil { continue }` guard in `MakeRequestAndGetData`. Every code path in `providers.NewRequest` and its underlying HTTP client either returns `(nil, err)` on error or `(resp, nil)` on success — `(nil, nil)` is never produced.

## Verification

Traced all 14 provider implementations (`anyapi`, `deepseek`, `gemini`, `groq`, `isou`, `koboldai`, `litellm`, `minimax`, `ollama`, `ollamacloud`, `opencode`, `openai`, `pollinations`, `powerbrain`). Every one of them:
- Terminates (`os.Exit(1)` / `log.Fatal()`) on internal errors (client creation, JSON marshal, request build)
- Returns `client.Do(req)` as the sole success path

`client.Do(req)` (tls-client → fhttp) follows the standard HTTP contract: `(resp, nil)` on success, `(nil, err)` on failure. No path produces `(nil, nil)`.

## Impact

Removes unreachable code that only provided a false sense of safety.

Closes #448

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when a provider request fails and no alternative providers remain.
  * Connection errors are now reported consistently, including when no response is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->