### PR TITLE
fix: warn when all rotation providers are invalid

### DIFF
--- a/src/helper/helper.go
+++ b/src/helper/helper.go
@@ -824,6 +824,7 @@ func providersForRotation(params structs.Params) []string {
 		}
 	}
 	if len(list) == 0 {
+		fmt.Fprintf(os.Stderr, "\rWarning: all rotation providers are invalid, falling back to %s\n", params.Provider)
 		list = []string{params.Provider}
 	}
 	return list


### PR DESCRIPTION
## Description

When every entry in the rotation list (`--rotate`) is invalid, `providersForRotation` silently falls back to `params.Provider`. If that provider is also invalid, the user sees only a generic "Invalid provider" error with no context that rotation was involved.

## Fix

Added a `fmt.Fprintf` warning to stderr when the rotation list is fully filtered out:

```
Warning: all rotation providers are invalid, falling back to opencode
```

This makes the root cause clear — the user knows that their `--rotate` entries were invalid and which provider is being used as fallback.

## Testing

- `go build` ✅
- `go test -vet=off ./...` ✅

Closes #447

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a warning when configured provider rotation entries are invalid.
  * Clearly indicates that the system is falling back to the originally selected provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->