### PR TITLE
fix: prepend primary provider before rotation fallbacks

### DIFF
--- a/src/helper/helper.go
+++ b/src/helper/helper.go
@@ -813,36 +813,37 @@ func providersForRotation(params structs.Params) []string {
 		return []string{params.Provider}
 	}
 	raw := strings.Split(params.RotateProviders, ",")
-	seen := make(map[string]bool, len(raw))
 	list := make([]string, 0, len(raw))
 	for _, p := range raw {
 		p = strings.TrimSpace(p)
-		if p == "" || seen[p] {
+		if p == "" {
 			continue
 		}
 		if providers.IsValidProvider(p) {
-			seen[p] = true
 			list = append(list, p)
 		}
 	}
 	if len(list) == 0 {
-		list = []string{params.Provider}
-		return list
+		return []string{params.Provider}
 	}
 
-	// Prepend the primary provider as the first attempt, treating rotation
-	// entries as true fallbacks. Skip if empty (no explicit primary) or invalid.
+	// Deduplicate all providers while preserving order, prepending
+	// the primary provider as the first attempt so rotation entries
+	// act as true fallbacks.
+	deduped := make([]string, 0, len(list)+1)
+	seen := make(map[string]struct{}, len(list)+1)
 	if params.Provider != "" && providers.IsValidProvider(params.Provider) {
-		// Remove primary from rotation list if present (deduplicate)
-		deduped := make([]string, 0, len(list))
-		for _, p := range list {
-			if p != params.Provider {
-				deduped = append(deduped, p)
-			}
-		}
-		list = append([]string{params.Provider}, deduped...)
+		deduped = append(deduped, params.Provider)
+		seen[params.Provider] = struct{}{}
 	}
-	return list
+	for _, p := range list {
+		if _, ok := seen[p]; ok {
+			continue
+		}
+		seen[p] = struct{}{}
+		deduped = append(deduped, p)
+	}
+	return deduped
 }
 
 func ShowHelpMessage() {

--- a/src/helper/helper.go
+++ b/src/helper/helper.go
@@ -825,6 +825,20 @@ func providersForRotation(params structs.Params) []string {
 	}
 	if len(list) == 0 {
 		list = []string{params.Provider}
+		return list
+	}
+
+	// Prepend the primary provider as the first attempt, treating rotation
+	// entries as true fallbacks. Skip if empty (no explicit primary) or invalid.
+	if params.Provider != "" && providers.IsValidProvider(params.Provider) {
+		// Deduplicate: remove primary from rotation list if present
+		deduped := make([]string, 0, len(list))
+		for _, p := range list {
+			if p != params.Provider {
+				deduped = append(deduped, p)
+			}
+		}
+		list = append([]string{params.Provider}, deduped...)
 	}
 	return list
 }

--- a/src/helper/helper.go
+++ b/src/helper/helper.go
@@ -813,13 +813,15 @@ func providersForRotation(params structs.Params) []string {
 		return []string{params.Provider}
 	}
 	raw := strings.Split(params.RotateProviders, ",")
+	seen := make(map[string]bool, len(raw))
 	list := make([]string, 0, len(raw))
 	for _, p := range raw {
 		p = strings.TrimSpace(p)
-		if p == "" {
+		if p == "" || seen[p] {
 			continue
 		}
 		if providers.IsValidProvider(p) {
+			seen[p] = true
 			list = append(list, p)
 		}
 	}
@@ -831,7 +833,7 @@ func providersForRotation(params structs.Params) []string {
 	// Prepend the primary provider as the first attempt, treating rotation
 	// entries as true fallbacks. Skip if empty (no explicit primary) or invalid.
 	if params.Provider != "" && providers.IsValidProvider(params.Provider) {
-		// Deduplicate: remove primary from rotation list if present
+		// Remove primary from rotation list if present (deduplicate)
 		deduped := make([]string, 0, len(list))
 		for _, p := range list {
 			if p != params.Provider {


### PR DESCRIPTION
## Description

When `--rotate` was specified, the rotation list completely replaced the primary provider. The documentation called these "fallback providers", but the primary was never tried.

Example:
```bash
AI_PROVIDER=openai tgpt --rotate "gemini,pollinations" "hello"
```
- **Before:** only gemini and pollinations were tried
- **After:** openai is tried first, then gemini and pollinations as true fallbacks

## Behavior

| Scenario | Result |
|----------|--------|
| `AI_PROVIDER=openai` + `--rotate gemini` | `[openai, gemini]` |
| `AI_PROVIDER=openai` + `--rotate openai,gemini` | `[openai, gemini]` (deduplicated) |
| No primary + `--rotate gemini,pollinations` | `[gemini, pollinations]` (no primary to prepend) |
| All rotation invalid + fallback | Falls back to primary (unchanged) |

## Testing
- `go build` ✅
- `go test -vet=off ./...` ✅

Closes #442

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved provider rotation behavior when multiple providers are configured.
  - Ensures the primary provider is attempted first when applicable.
  - Prevents duplicate attempts during rotation while preserving the intended order.
  - If no valid rotated providers are available, the system now reliably falls back to the configured primary provider.
  - Result: more predictable selection and fewer redundant retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->