### PR TITLE
fix: deduplicate provider entries in rotation list

### DIFF
--- a/src/helper/helper.go
+++ b/src/helper/helper.go
@@ -813,13 +813,15 @@ func providersForRotation(params structs.Params) []string {
 		return []string{params.Provider}
 	}
 	raw := strings.Split(params.RotateProviders, ",")
+	seen := make(map[string]bool, len(raw))
 	list := make([]string, 0, len(raw))
 	for _, p := range raw {
 		p = strings.TrimSpace(p)
-		if p == "" {
+		if p == "" || seen[p] {
 			continue
 		}
 		if providers.IsValidProvider(p) {
+			seen[p] = true
 			list = append(list, p)
 		}
 	}


### PR DESCRIPTION
## Description

Duplicate provider names in the `--rotate` list are no longer attempted multiple times. A `map[string]bool` tracker silently skips entries already seen.

## Example

```bash
tgpt --rotate "gemini,gemini,opencode" "hello"
```

- **Before:** gemini tried twice, producing duplicate error messages on failure
- **After:** gemini tried once, then opencode

Closes #446

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider rotation configuration by trimming whitespace, ignoring invalid entries, and removing duplicates.
  * Preserved the existing fallback behavior when no valid providers are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->