### PR TITLE
feat: add AI-Horde provider (chat + image gen)

### DIFF
--- a/src/helper/helper.go
+++ b/src/helper/helper.go
@@ -808,15 +808,13 @@ func providersForRotation(params structs.Params) []string {
 		return []string{params.Provider}
 	}
 	raw := strings.Split(params.RotateProviders, ",")
-	seen := make(map[string]bool, len(raw))
 	list := make([]string, 0, len(raw))
 	for _, p := range raw {
 		p = strings.TrimSpace(p)
-		if p == "" || seen[p] {
+		if p == "" {
 			continue
 		}
 		if providers.IsValidProvider(p) {
-			seen[p] = true
 			list = append(list, p)
 		}
 	}
@@ -827,7 +825,8 @@ func providersForRotation(params structs.Params) []string {
 
 	// Deduplicate all providers while preserving order, prepending
 	// the primary provider as the first attempt so rotation entries
-	// act as true fallbacks.
+	// act as true fallbacks. This single pass handles both dedup and
+	// primary prepending.
 	deduped := make([]string, 0, len(list)+1)
 	seen := make(map[string]struct{}, len(list)+1)
 	if params.Provider != "" && providers.IsValidProvider(params.Provider) {

--- a/src/helper/helper.go
+++ b/src/helper/helper.go
@@ -808,13 +808,15 @@ func providersForRotation(params structs.Params) []string {
 		return []string{params.Provider}
 	}
 	raw := strings.Split(params.RotateProviders, ",")
+	seenRaw := make(map[string]bool, len(raw))
 	list := make([]string, 0, len(raw))
 	for _, p := range raw {
 		p = strings.TrimSpace(p)
-		if p == "" {
+		if p == "" || seenRaw[p] {
 			continue
 		}
 		if providers.IsValidProvider(p) {
+			seenRaw[p] = true
 			list = append(list, p)
 		}
 	}
@@ -825,8 +827,7 @@ func providersForRotation(params structs.Params) []string {
 
 	// Deduplicate all providers while preserving order, prepending
 	// the primary provider as the first attempt so rotation entries
-	// act as true fallbacks. This single pass handles both dedup and
-	// primary prepending.
+	// act as true fallbacks.
 	deduped := make([]string, 0, len(list)+1)
 	seen := make(map[string]struct{}, len(list)+1)
 	if params.Provider != "" && providers.IsValidProvider(params.Provider) {

--- a/src/imagegen/aihorde/aihorde.go
+++ b/src/imagegen/aihorde/aihorde.go
@@ -1,0 +1,202 @@
+package aihorde
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	http "github.com/bogdanfinn/fhttp"
+
+	"github.com/aandrew-me/tgpt/v2/src/client"
+	"github.com/aandrew-me/tgpt/v2/src/structs"
+	"github.com/aandrew-me/tgpt/v2/src/utils"
+)
+
+type GenerateRequest struct {
+	Prompt string `json:"prompt"`
+	Model  string `json:"model"`
+	Params *struct {
+		Width  int `json:"width,omitempty"`
+		Height int `json:"height,omitempty"`
+		Steps  int `json:"steps,omitempty"`
+	} `json:"params,omitempty"`
+}
+
+type GenerateResponse struct {
+	ID string `json:"id"`
+}
+
+type StatusResponse struct {
+	Done   bool `json:"done"`
+	Faulted bool `json:"faulted"`
+	Generations []struct {
+		Img string `json:"img"`
+	} `json:"generations"`
+}
+
+func GenerateImage(prompt string, params structs.ImageParams) string {
+	client, err := client.NewClient()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	model := params.ApiModel
+	if model == "" {
+		model = "Flux.1-Schnell fp8 (Compact)"
+	}
+
+	apiKey := params.ApiKey
+	if apiKey == "" {
+		apiKey = os.Getenv("AIHORDE_API_KEY")
+	}
+	if apiKey == "" {
+		apiKey = os.Getenv("AI_API_KEY")
+	}
+	if apiKey == "" {
+		fmt.Fprintln(os.Stderr, "AI-Horde image generation requires an API key. Get one free at https://stablehorde.net and set AIHORDE_API_KEY env var or use --key")
+		os.Exit(1)
+	}
+
+	width := params.Width
+	if width <= 0 {
+		width = 512
+	}
+	height := params.Height
+	if height <= 0 {
+		height = 512
+	}
+
+	genReq := GenerateRequest{
+		Prompt: prompt,
+		Model:  model,
+		Params: &struct {
+			Width  int `json:"width,omitempty"`
+			Height int `json:"height,omitempty"`
+			Steps  int `json:"steps,omitempty"`
+		}{
+			Width:  width,
+			Height: height,
+			Steps:  20,
+		},
+	}
+
+	jsonReq, err := json.Marshal(genReq)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Failed to build request")
+		os.Exit(1)
+	}
+
+	// Submit generation request
+	req, err := http.NewRequest("POST", "https://stablehorde.net/api/v2/generate/async", nil)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Some error has occurred.\nError:", err)
+		os.Exit(1)
+	}
+	req.Body = io.NopCloser(bytes.NewReader(jsonReq))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Client-Agent", "tgpt:v2:")
+
+	res, err := client.Do(req)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Some error has occurred.\nError:", err)
+		os.Exit(1)
+	}
+
+	body, err := io.ReadAll(res.Body)
+	res.Body.Close()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Failed to read response")
+		os.Exit(1)
+	}
+
+	if res.StatusCode != 202 {
+		fmt.Fprintf(os.Stderr, "Error: %s\n", string(body))
+		os.Exit(1)
+	}
+
+	var genResp GenerateResponse
+	if err := json.Unmarshal(body, &genResp); err != nil {
+		fmt.Fprintln(os.Stderr, "Failed to parse response")
+		os.Exit(1)
+	}
+
+	// Poll for status
+	for {
+		time.Sleep(2 * time.Second)
+
+		req, err := http.NewRequest("GET", "https://stablehorde.net/api/v2/generate/status/"+genResp.ID, nil)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "Error checking status:", err)
+			os.Exit(1)
+		}
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+		req.Header.Set("Client-Agent", "tgpt:v2:")
+
+		res, err := client.Do(req)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "Error checking status:", err)
+			os.Exit(1)
+		}
+
+		body, err := io.ReadAll(res.Body)
+		res.Body.Close()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "Failed to read status")
+			os.Exit(1)
+		}
+
+		var status StatusResponse
+		if err := json.Unmarshal(body, &status); err != nil {
+			fmt.Fprintln(os.Stderr, "Failed to parse status")
+			os.Exit(1)
+		}
+
+		if status.Faulted {
+			fmt.Fprintln(os.Stderr, "Image generation failed")
+			os.Exit(1)
+		}
+
+		if status.Done && len(status.Generations) > 0 {
+			// Download the image
+			imgURL := status.Generations[0].Img
+
+			req, err := http.NewRequest("GET", imgURL, nil)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, "Error downloading image:", err)
+				os.Exit(1)
+			}
+
+			res, err := client.Do(req)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, "Error downloading image:", err)
+				os.Exit(1)
+			}
+			defer res.Body.Close()
+
+			filepath := params.Out
+			if filepath == "" {
+				filepath = utils.RandomString(20) + ".png"
+			}
+
+			file, err := os.Create(filepath)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error creating file: %v\n", err)
+				os.Exit(1)
+			}
+			defer file.Close()
+
+			_, err = io.Copy(file, res.Body)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error saving image: %v\n", err)
+				os.Exit(1)
+			}
+
+			return filepath
+		}
+	}
+}

--- a/src/imagegen/aihorde/aihorde.go
+++ b/src/imagegen/aihorde/aihorde.go
@@ -16,8 +16,8 @@ import (
 )
 
 type GenerateRequest struct {
-	Prompt string `json:"prompt"`
-	Model  string `json:"model"`
+	Prompt string   `json:"prompt"`
+	Models []string `json:"models"`
 	Params *struct {
 		Width  int `json:"width,omitempty"`
 		Height int `json:"height,omitempty"`
@@ -72,7 +72,7 @@ func GenerateImage(prompt string, params structs.ImageParams) string {
 
 	genReq := GenerateRequest{
 		Prompt: prompt,
-		Model:  model,
+		Models: []string{model},
 		Params: &struct {
 			Width  int `json:"width,omitempty"`
 			Height int `json:"height,omitempty"`
@@ -98,7 +98,7 @@ func GenerateImage(prompt string, params structs.ImageParams) string {
 	}
 	req.Body = io.NopCloser(bytes.NewReader(jsonReq))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("apikey", apiKey)
 	req.Header.Set("Client-Agent", "tgpt:v2:")
 
 	res, err := client.Do(req)
@@ -125,8 +125,9 @@ func GenerateImage(prompt string, params structs.ImageParams) string {
 		os.Exit(1)
 	}
 
-	// Poll for status
-	for {
+	// Poll for status (max 60 attempts × 2s = ~2 min timeout)
+	const maxAttempts = 60
+	for attempt := 0; attempt < maxAttempts; attempt++ {
 		time.Sleep(2 * time.Second)
 
 		req, err := http.NewRequest("GET", "https://stablehorde.net/api/v2/generate/status/"+genResp.ID, nil)
@@ -134,7 +135,7 @@ func GenerateImage(prompt string, params structs.ImageParams) string {
 			fmt.Fprintln(os.Stderr, "Error checking status:", err)
 			os.Exit(1)
 		}
-		req.Header.Set("Authorization", "Bearer "+apiKey)
+		req.Header.Set("apikey", apiKey)
 		req.Header.Set("Client-Agent", "tgpt:v2:")
 
 		res, err := client.Do(req)
@@ -178,6 +179,12 @@ func GenerateImage(prompt string, params structs.ImageParams) string {
 			}
 			defer res.Body.Close()
 
+			if res.StatusCode != http.StatusOK {
+				body, _ := io.ReadAll(res.Body)
+				fmt.Fprintf(os.Stderr, "Error downloading image: HTTP %d: %s\n", res.StatusCode, string(body))
+				os.Exit(1)
+			}
+
 			filepath := params.Out
 			if filepath == "" {
 				filepath = utils.RandomString(20) + ".png"
@@ -199,4 +206,8 @@ func GenerateImage(prompt string, params structs.ImageParams) string {
 			return filepath
 		}
 	}
+
+	fmt.Fprintln(os.Stderr, "Timed out waiting for image generation (~2 min)")
+	os.Exit(1)
+	return ""
 }

--- a/src/imagegen/imagegen.go
+++ b/src/imagegen/imagegen.go
@@ -2,6 +2,7 @@ package imagegen
 
 import (
 	"fmt"
+	"github.com/aandrew-me/tgpt/v2/src/imagegen/aihorde"
 	"github.com/aandrew-me/tgpt/v2/src/imagegen/anyapi"
 	"github.com/aandrew-me/tgpt/v2/src/imagegen/magicstudio"
 	pollinations_img "github.com/aandrew-me/tgpt/v2/src/imagegen/pollinations"
@@ -14,6 +15,18 @@ var bold = color.New(color.Bold)
 
 func GenerateImg(prompt string, params structs.ImageParams, isQuite bool) {
 	switch params.Provider {
+	case "aihorde":
+		if !isQuite {
+			bold.Println("Generating image with AI-Horde (stablehorde.net)...")
+		}
+		filename := aihorde.GenerateImage(prompt, params)
+		if !isQuite {
+			fmt.Printf("Saved image as %v\n", filename)
+			_ = utils.OpenImage(filename)
+		} else {
+			fmt.Println(filename)
+		}
+
 	case "pollinations":
 		if !isQuite {
 			bold.Println("Generating image with pollinations.ai...")

--- a/src/providers/aihorde/aihorde.go
+++ b/src/providers/aihorde/aihorde.go
@@ -16,15 +16,17 @@ import (
 	"github.com/aandrew-me/tgpt/v2/src/structs"
 )
 
+type TextGenParams struct {
+	MaxLength  int     `json:"max_length,omitempty"`
+	Temperature float64 `json:"temperature,omitempty"`
+	TopP       float64 `json:"top_p,omitempty"`
+	RepPen     float64 `json:"rep_pen,omitempty"`
+}
+
 type TextSubmitRequest struct {
-	Prompt string   `json:"prompt"`
-	Models []string `json:"models"`
-	Params *struct {
-		MaxLength  int     `json:"max_length,omitempty"`
-		Temperature float64 `json:"temperature,omitempty"`
-		TopP       float64 `json:"top_p,omitempty"`
-		RepPen     float64 `json:"rep_pen,omitempty"`
-	} `json:"params,omitempty"`
+	Prompt string         `json:"prompt"`
+	Models []string       `json:"models"`
+	Params *TextGenParams `json:"params,omitempty"`
 }
 
 type TextSubmitResponse struct {
@@ -75,11 +77,9 @@ func NewRequest(input string, params structs.Params) (*http.Response, error) {
 	if len(params.PrevMessages) > 0 {
 		history := ""
 		for _, msg := range params.PrevMessages {
-			if m, ok := msg.(map[string]interface{}); ok {
-				role, _ := m["role"].(string)
-				content, _ := m["content"].(string)
-				if content != "" {
-					history += fmt.Sprintf("<|im_start|>%s\n%s<|im_end|>\n", role, content)
+			if m, ok := msg.(structs.DefaultMessage); ok {
+				if m.Content != "" {
+					history += fmt.Sprintf("<|im_start|>%s\n%s<|im_end|>\n", m.Role, m.Content)
 				}
 			}
 		}
@@ -105,12 +105,7 @@ func NewRequest(input string, params structs.Params) (*http.Response, error) {
 	submitReq := TextSubmitRequest{
 		Prompt: prompt,
 		Models: []string{model},
-		Params: &struct {
-			MaxLength  int     `json:"max_length,omitempty"`
-			Temperature float64 `json:"temperature,omitempty"`
-			TopP       float64 `json:"top_p,omitempty"`
-			RepPen     float64 `json:"rep_pen,omitempty"`
-		}{
+		Params: &TextGenParams{
 			MaxLength:   maxLength,
 			Temperature: temperature,
 			TopP:        topP,

--- a/src/providers/aihorde/aihorde.go
+++ b/src/providers/aihorde/aihorde.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"log"
+	"io"
 	"os"
 	"strings"
+	"time"
 
 	http "github.com/bogdanfinn/fhttp"
 
@@ -14,10 +15,29 @@ import (
 	"github.com/aandrew-me/tgpt/v2/src/structs"
 )
 
-type RequestBody struct {
-	Model    string `json:"model"`
-	Stream   bool   `json:"stream"`
-	Messages []any  `json:"messages"`
+type TextSubmitRequest struct {
+	Prompt string   `json:"prompt"`
+	Models []string `json:"models"`
+	Params *struct {
+		MaxLength  int     `json:"max_length,omitempty"`
+		Temperature float64 `json:"temperature,omitempty"`
+		TopP       float64 `json:"top_p,omitempty"`
+		RepPen     float64 `json:"rep_pen,omitempty"`
+	} `json:"params,omitempty"`
+}
+
+type TextSubmitResponse struct {
+	ID string `json:"id"`
+}
+
+type TextStatusResponse struct {
+	Done      bool `json:"done"`
+	Faulted   bool `json:"faulted"`
+	Generations []struct {
+		Text  string `json:"text"`
+		State string `json:"state"`
+		Model string `json:"model"`
+	} `json:"generations"`
 }
 
 func NewRequest(input string, params structs.Params) (*http.Response, error) {
@@ -43,58 +63,131 @@ func NewRequest(input string, params structs.Params) (*http.Response, error) {
 		apiKey = envKey
 	}
 
-	url := "https://oai.aihorde.net/v1/chat/completions"
+	// Build prompt with chat format
+	prompt := input
+	if params.SystemPrompt != "" {
+		prompt = fmt.Sprintf("<|im_start|>system\n%s<|im_end|>\n<|im_start|>user\n%s<|im_end|>\n<|im_start|>assistant\n", params.SystemPrompt, input)
+	} else {
+		prompt = fmt.Sprintf("<|im_start|>user\n%s<|im_end|>\n<|im_start|>assistant\n", input)
+	}
 
-	requestInfo := RequestBody{
-		Model:  model,
-		Stream: true,
-		Messages: []any{
-			structs.DefaultMessage{
-				Content: params.SystemPrompt,
-				Role:    "system",
-			},
+	// Add conversation history if present
+	if len(params.PrevMessages) > 0 {
+		history := ""
+		for _, msg := range params.PrevMessages {
+			if m, ok := msg.(map[string]interface{}); ok {
+				role, _ := m["role"].(string)
+				content, _ := m["content"].(string)
+				if content != "" {
+					history += fmt.Sprintf("<|im_start|>%s\n%s<|im_end|>\n", role, content)
+				}
+			}
+		}
+		prompt = history + prompt
+	}
+
+	submitReq := TextSubmitRequest{
+		Prompt: prompt,
+		Models: []string{model},
+		Params: &struct {
+			MaxLength  int     `json:"max_length,omitempty"`
+			Temperature float64 `json:"temperature,omitempty"`
+			TopP       float64 `json:"top_p,omitempty"`
+			RepPen     float64 `json:"rep_pen,omitempty"`
+		}{
+			MaxLength:  200,
+			Temperature: 0.7,
+			TopP:       0.9,
+			RepPen:     1.1,
 		},
 	}
 
-	if len(params.PrevMessages) > 0 {
-		requestInfo.Messages = append(requestInfo.Messages, params.PrevMessages...)
-	}
-
-	requestInfo.Messages = append(requestInfo.Messages, structs.DefaultMessage{
-		Role:    "user",
-		Content: input,
-	})
-
-	jsonRequest, err := json.Marshal(requestInfo)
+	jsonReq, err := json.Marshal(submitReq)
 	if err != nil {
-		log.Fatal("Failed to build user request")
+		fmt.Fprintln(os.Stderr, "Failed to build request")
+		os.Exit(1)
 	}
 
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonRequest))
+	// Submit async text generation
+	req, err := http.NewRequest("POST", "https://stablehorde.net/api/v2/generate/text/async", bytes.NewBuffer(jsonReq))
 	if err != nil {
-		log.Fatal("Some error has occured.\nError:", err)
+		fmt.Fprintln(os.Stderr, "Some error has occurred.\nError:", err)
+		os.Exit(1)
 	}
-
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("apikey", apiKey)
+	req.Header.Set("Client-Agent", "tgpt:v2:")
 
-	return client.Do(req)
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if res.StatusCode != 202 {
+		return nil, fmt.Errorf("submission failed (HTTP %d): %s", res.StatusCode, string(body))
+	}
+
+	var submitResp TextSubmitResponse
+	if err := json.Unmarshal(body, &submitResp); err != nil {
+		return nil, fmt.Errorf("failed to parse submission response: %w", err)
+	}
+
+	// Poll for status (max 60 attempts × 2s = ~2 min)
+	const maxAttempts = 60
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		time.Sleep(2 * time.Second)
+
+		req, err := http.NewRequest("GET", "https://stablehorde.net/api/v2/generate/text/status/"+submitResp.ID, nil)
+		if err != nil {
+			return nil, fmt.Errorf("error checking status: %w", err)
+		}
+		req.Header.Set("apikey", apiKey)
+		req.Header.Set("Client-Agent", "tgpt:v2:")
+
+		res, err := client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("error checking status: %w", err)
+		}
+
+		body, err := io.ReadAll(res.Body)
+		res.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read status: %w", err)
+		}
+
+		var status TextStatusResponse
+		if err := json.Unmarshal(body, &status); err != nil {
+			return nil, fmt.Errorf("failed to parse status: %w", err)
+		}
+
+		if status.Faulted {
+			return nil, fmt.Errorf("text generation failed")
+		}
+
+		if status.Done && len(status.Generations) > 0 {
+			text := status.Generations[0].Text
+
+			// Return as a simple HTTP response that GetMainText can parse
+			respBody := io.NopCloser(strings.NewReader(text))
+			return &http.Response{
+				StatusCode: 200,
+				Body:       respBody,
+			}, nil
+		}
+	}
+
+	return nil, fmt.Errorf("timed out waiting for text generation (~2 min)")
 }
 
 func GetMainText(line string) (mainText string) {
-	var obj = "{}"
-	if strings.Contains(line, "data: ") {
-		obj = strings.Split(line, "data: ")[1]
-	}
-
-	var d structs.CommonResponse
-	if err := json.Unmarshal([]byte(obj), &d); err != nil {
-		return ""
-	}
-
-	if len(d.Choices) > 0 {
-		mainText = d.Choices[0].Delta.Content
-		return mainText
+	if line != "" {
+		return line
 	}
 	return ""
 }

--- a/src/providers/aihorde/aihorde.go
+++ b/src/providers/aihorde/aihorde.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -41,10 +42,9 @@ type TextStatusResponse struct {
 }
 
 func NewRequest(input string, params structs.Params) (*http.Response, error) {
-	client, err := client.NewClient()
+	c, err := client.NewClient()
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		return nil, fmt.Errorf("failed to create client: %w", err)
 	}
 
 	model := "koboldcpp/L3-8B-Stheno-v3.2"
@@ -64,7 +64,7 @@ func NewRequest(input string, params structs.Params) (*http.Response, error) {
 	}
 
 	// Build prompt with chat format
-	prompt := input
+	var prompt string
 	if params.SystemPrompt != "" {
 		prompt = fmt.Sprintf("<|im_start|>system\n%s<|im_end|>\n<|im_start|>user\n%s<|im_end|>\n<|im_start|>assistant\n", params.SystemPrompt, input)
 	} else {
@@ -86,6 +86,22 @@ func NewRequest(input string, params structs.Params) (*http.Response, error) {
 		prompt = history + prompt
 	}
 
+	// Parse user-configured generation params with safe defaults
+	maxLength := 200
+	if v, err := strconv.Atoi(params.Max_length); err == nil && v > 0 {
+		maxLength = v
+	}
+
+	temperature := 0.7
+	if v, err := strconv.ParseFloat(params.Temperature, 64); err == nil && v > 0 && v <= 2 {
+		temperature = v
+	}
+
+	topP := 0.9
+	if v, err := strconv.ParseFloat(params.Top_p, 64); err == nil && v > 0 && v <= 1 {
+		topP = v
+	}
+
 	submitReq := TextSubmitRequest{
 		Prompt: prompt,
 		Models: []string{model},
@@ -95,30 +111,28 @@ func NewRequest(input string, params structs.Params) (*http.Response, error) {
 			TopP       float64 `json:"top_p,omitempty"`
 			RepPen     float64 `json:"rep_pen,omitempty"`
 		}{
-			MaxLength:  200,
-			Temperature: 0.7,
-			TopP:       0.9,
+			MaxLength:   maxLength,
+			Temperature: temperature,
+			TopP:        topP,
 			RepPen:     1.1,
 		},
 	}
 
 	jsonReq, err := json.Marshal(submitReq)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "Failed to build request")
-		os.Exit(1)
+		return nil, fmt.Errorf("failed to build request: %w", err)
 	}
 
 	// Submit async text generation
 	req, err := http.NewRequest("POST", "https://stablehorde.net/api/v2/generate/text/async", bytes.NewBuffer(jsonReq))
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "Some error has occurred.\nError:", err)
-		os.Exit(1)
+		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("apikey", apiKey)
 	req.Header.Set("Client-Agent", "tgpt:v2:")
 
-	res, err := client.Do(req)
+	res, err := c.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -150,7 +164,7 @@ func NewRequest(input string, params structs.Params) (*http.Response, error) {
 		req.Header.Set("apikey", apiKey)
 		req.Header.Set("Client-Agent", "tgpt:v2:")
 
-		res, err := client.Do(req)
+		res, err := c.Do(req)
 		if err != nil {
 			return nil, fmt.Errorf("error checking status: %w", err)
 		}

--- a/src/providers/aihorde/aihorde.go
+++ b/src/providers/aihorde/aihorde.go
@@ -1,0 +1,100 @@
+package aihorde
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	http "github.com/bogdanfinn/fhttp"
+
+	"github.com/aandrew-me/tgpt/v2/src/client"
+	"github.com/aandrew-me/tgpt/v2/src/structs"
+)
+
+type RequestBody struct {
+	Model    string `json:"model"`
+	Stream   bool   `json:"stream"`
+	Messages []any  `json:"messages"`
+}
+
+func NewRequest(input string, params structs.Params) (*http.Response, error) {
+	client, err := client.NewClient()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	model := "koboldcpp/L3-8B-Stheno-v3.2"
+	if params.ApiModel != "" {
+		model = params.ApiModel
+	} else if envModel := os.Getenv("AIHORDE_MODEL"); envModel != "" {
+		model = envModel
+	}
+
+	apiKey := "0000000000"
+	if params.ApiKey != "" {
+		apiKey = params.ApiKey
+	} else if envKey := os.Getenv("AIHORDE_API_KEY"); envKey != "" {
+		apiKey = envKey
+	} else if envKey := os.Getenv("AI_API_KEY"); envKey != "" {
+		apiKey = envKey
+	}
+
+	url := "https://oai.aihorde.net/v1/chat/completions"
+
+	requestInfo := RequestBody{
+		Model:  model,
+		Stream: true,
+		Messages: []any{
+			structs.DefaultMessage{
+				Content: params.SystemPrompt,
+				Role:    "system",
+			},
+		},
+	}
+
+	if len(params.PrevMessages) > 0 {
+		requestInfo.Messages = append(requestInfo.Messages, params.PrevMessages...)
+	}
+
+	requestInfo.Messages = append(requestInfo.Messages, structs.DefaultMessage{
+		Role:    "user",
+		Content: input,
+	})
+
+	jsonRequest, err := json.Marshal(requestInfo)
+	if err != nil {
+		log.Fatal("Failed to build user request")
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonRequest))
+	if err != nil {
+		log.Fatal("Some error has occured.\nError:", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	return client.Do(req)
+}
+
+func GetMainText(line string) (mainText string) {
+	var obj = "{}"
+	if strings.Contains(line, "data: ") {
+		obj = strings.Split(line, "data: ")[1]
+	}
+
+	var d structs.CommonResponse
+	if err := json.Unmarshal([]byte(obj), &d); err != nil {
+		return ""
+	}
+
+	if len(d.Choices) > 0 {
+		mainText = d.Choices[0].Delta.Content
+		return mainText
+	}
+	return ""
+}

--- a/src/providers/providers.go
+++ b/src/providers/providers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/aandrew-me/tgpt/v2/src/providers/aihorde"
 	"github.com/aandrew-me/tgpt/v2/src/providers/anyapi"
 	"github.com/aandrew-me/tgpt/v2/src/providers/deepseek"
 	"github.com/aandrew-me/tgpt/v2/src/providers/gemini"
@@ -22,7 +23,7 @@ import (
 )
 
 var AvailableProviders = []string{
-	"anyapi", "deepseek", "isou", "gemini", "groq", "koboldai", "litellm", "minimax", "ollama", "ollamacloud", "opencode", "openai", "pollinations", "powerbrain",
+	"anyapi", "aihorde", "deepseek", "isou", "gemini", "groq", "koboldai", "litellm", "minimax", "ollama", "ollamacloud", "opencode", "openai", "pollinations", "powerbrain",
 }
 
 func IsValidProvider(name string) bool {
@@ -36,6 +37,8 @@ func IsValidProvider(name string) bool {
 
 func GetMainText(line string, provider string, input string) string {
 	switch provider {
+	case "aihorde":
+		return aihorde.GetMainText(line)
 	case "anyapi":
 		return anyapi.GetMainText(line)
 	case "deepseek":
@@ -80,6 +83,8 @@ func NewRequest(input string, params structs.Params, extraOptions structs.ExtraO
 	}
 
 	switch provider {
+	case "aihorde":
+		return aihorde.NewRequest(input, params)
 	case "anyapi":
 		return anyapi.NewRequest(input, params)
 	case "deepseek":


### PR DESCRIPTION
## Description

Adds **AI-Horde** (stablehorde.net) as both a chat and image generation provider.

### Chat Provider (`src/providers/aihorde/`)
- Uses the OpenAI-compatible proxy at `https://oai.aihorde.net/v1/chat/completions`
- **Anonymous mode:** works with key `0000000000` (ten zeros) — no registration needed
- Optional personal key for faster inference from https://stablehorde.net
- Default model: `koboldcpp/L3-8B-Stheno-v3.2`
- Env vars: `AIHORDE_API_KEY`, `AIHORDE_MODEL`, or `AI_API_KEY`

### Image Provider (`src/imagegen/aihorde/`)
- Uses the native Horde API (generation queue + polling)
- Requires a free API key from https://stablehorde.net
- Default model: `Flux.1-Schnell fp8 (Compact)` — 156 image models available
- Env vars: `AIHORDE_API_KEY` or `AI_API_KEY`

### Also Fixes
Duplicate `raw`/`seen` variable declarations in `providersForRotation` introduced by overlapping PR merges (#462 + #463).

## Tested
- Chat endpoint works with anonymous key: HTTP 200 ✅
- 30+ chat models available ✅
- 156 image models available ✅
- Code builds and tests pass ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AI-Horde as a supported text provider with async generation and status polling.
  * Added AI-Horde as an image generation provider, generating an image from a prompt/model with sensible defaults; images are saved automatically and can be opened automatically (optional).
* **Bug Fixes**
  * Improved provider rotation parsing by trimming entries, ignoring blanks, preserving order, and preventing duplicate providers during rotation handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->