### PR TITLE
feat: add Ctrl+Z support to suspend to parent shell

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"syscall"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/aandrew-me/tgpt/v2/src/bubbletea"
 	"github.com/aandrew-me/tgpt/v2/src/helper"
 	"github.com/aandrew-me/tgpt/v2/src/imagegen"
@@ -24,7 +25,6 @@ import (
 	"github.com/aandrew-me/tgpt/v2/src/tools"
 	"github.com/aandrew-me/tgpt/v2/src/utils"
 	Prompt "github.com/c-bata/go-prompt"
-	tea "charm.land/bubbletea/v2"
 	"github.com/fatih/color"
 )
 
@@ -269,6 +269,10 @@ func runInteractiveShellMode(
 				Key: Prompt.ControlC,
 				Fn:  exit,
 			}),
+			Prompt.OptionAddKeyBind(Prompt.KeyBind{
+				Key: Prompt.ControlZ,
+				Fn:  suspend,
+			}),
 		)
 		cmd := getAndPrintResponse(input)
 		execCmd(cmd)
@@ -302,12 +306,20 @@ func main() {
 		executablePath = execPath
 	}
 
-	terminate := make(chan os.Signal, 1)
-	signal.Notify(terminate, os.Interrupt, syscall.SIGTERM)
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, os.Interrupt, syscall.SIGTERM, syscall.SIGTSTP)
 	go func() {
-		<-terminate
-		restoreTerminal()
-		os.Exit(0)
+		for {
+			sig := <-sigs
+			switch sig {
+			case os.Interrupt, syscall.SIGTERM:
+				restoreTerminal()
+				os.Exit(0)
+			case syscall.SIGTSTP: // Suspend to parent shell (Ctrl+Z outside raw-mode input)
+				restoreTerminal()
+				syscall.Kill(syscall.Getpid(), syscall.SIGSTOP)
+			}
+		}
 	}()
 
 	apiModel := flag.String("model", "", "Choose which model to use")
@@ -713,6 +725,10 @@ func main() {
 						Key: Prompt.ControlC,
 						Fn:  exit,
 					}),
+					Prompt.OptionAddKeyBind(Prompt.KeyBind{
+						Key: Prompt.ControlZ,
+						Fn:  suspend,
+					}),
 				)
 				getAndPrintResponse(input)
 			}
@@ -823,6 +839,10 @@ func main() {
 						Key: Prompt.ControlC,
 						Fn:  exit,
 					}),
+					Prompt.OptionAddKeyBind(Prompt.KeyBind{
+						Key: Prompt.ControlZ,
+						Fn:  suspend,
+					}),
 				)
 				if len(input) > 0 {
 					getAndPrintFindResponse(input)
@@ -887,4 +907,13 @@ func exit(_ *Prompt.Buffer) {
 	bold.Println("Exiting...")
 	restoreTerminal()
 	os.Exit(0)
+}
+
+// suspend stops the process so the user can return to the parent shell
+// (job control). The terminal is restored to cooked mode first so the
+// shell regains control of the tty; go-prompt re-enters raw mode on the
+// next Input() call after `fg`.
+func suspend(_ *Prompt.Buffer) {
+	restoreTerminal()
+	syscall.Kill(syscall.Getpid(), syscall.SIGSTOP)
 }


### PR DESCRIPTION
Closes #392

## Summary
Adds job-control suspend support so users can drop back to the parent shell with **Ctrl+Z** (`fg` to resume) instead of quitting tgpt. Works in all interactive modes that use go-prompt (`-i`, `-is`, `-ia`, `-if`), plus while a response is streaming.

## Why two parts?
- **go-prompt keybind (`Ctrl+Z` → `suspend()`)** — inside `Prompt.Input` the tty is in raw mode, so Ctrl+Z is delivered as a key event (byte `0x1a`), never as `SIGTSTP`. A keybind is the only way to catch it there.
- **`SIGTSTP` in the signal handler** — covers everything outside raw-mode input (e.g. mid-stream while the model is generating), where the terminal *does* generate a real `SIGTSTP`.

`suspend()` restores the tty to cooked mode first (so the shell regains the terminal), then sends `SIGSTOP` to itself. After `fg`, go-prompt re-enters raw mode on the next `Input()` call automatically.

## Verification
- `go build ./...` ✅
- `go test ./...` ✅ (root package)
- `gofmt` clean ✅
- Behavioral pty test: Ctrl+Z byte in raw-mode prompt → process state `T` (stopped); `SIGCONT` → resumed; prompt re-renders; typing works after `fg`; external `SIGTSTP` during non-raw phase → also stops ✅

## Notes
- `-m` (multiline bubbletea) mode is intentionally not covered here — matches the scope of the original proposal; can be a follow-up.