### PR TITLE
Suspend on Ctrl+Z

### DIFF
--- a/main.go
+++ b/main.go
@@ -713,6 +713,10 @@ func main() {
 						Key: Prompt.ControlC,
 						Fn:  exit,
 					}),
+					Prompt.OptionAddKeyBind(Prompt.KeyBind{
+						Key: Prompt.ControlZ,
+						Fn:  suspend,
+					}),
 				)
 				getAndPrintResponse(input)
 			}
@@ -823,6 +827,10 @@ func main() {
 						Key: Prompt.ControlC,
 						Fn:  exit,
 					}),
+					Prompt.OptionAddKeyBind(Prompt.KeyBind{
+						Key: Prompt.ControlZ,
+						Fn:  suspend,
+					}),
 				)
 				if len(input) > 0 {
 					getAndPrintFindResponse(input)
@@ -888,3 +896,8 @@ func exit(_ *Prompt.Buffer) {
 	restoreTerminal()
 	os.Exit(0)
 }
+
+func suspend(_ *Prompt.Buffer) {
+	suspendProcess()
+}
+

--- a/src/bubbletea/bubbletea.go
+++ b/src/bubbletea/bubbletea.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 
 	"github.com/aandrew-me/tgpt/v2/src/utils"
@@ -73,6 +74,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if len(*userInput) > 1 {
 				m.textarea.Blur()
 				return m, tea.Quit
+			}
+		case "ctrl+z":
+			if runtime.GOOS != "windows" {
+				return m, tea.Suspend
 			}
 		case "tab":
 			if m.textarea.Focused() {

--- a/src/bubbletea/bubbletea_test.go
+++ b/src/bubbletea/bubbletea_test.go
@@ -1,0 +1,27 @@
+package bubbletea
+
+import (
+	"runtime"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func TestModelCtrlZ(t *testing.T) {
+	preprompt := ""
+	loop := true
+	lastResponse := ""
+	userInput := ""
+	m := InitialModel(&preprompt, &loop, &lastResponse, &userInput)
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: 'z', Mod: tea.ModCtrl})
+	if runtime.GOOS != "windows" {
+		if cmd == nil {
+			t.Errorf("expected suspend command for ctrl+z on non-windows, got nil")
+		}
+	} else {
+		if cmd != nil {
+			t.Errorf("expected nil command for ctrl+z on windows, got %v", cmd)
+		}
+	}
+}

--- a/suspend_unix.go
+++ b/suspend_unix.go
@@ -1,0 +1,17 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+func suspendProcess() {
+	restoreTerminal()
+	_ = syscall.Kill(os.Getpid(), syscall.SIGTSTP)
+	rawModeOn := exec.Command("stty", "raw", "-echo")
+	rawModeOn.Stdin = os.Stdin
+	_ = rawModeOn.Run()
+}

--- a/suspend_windows.go
+++ b/suspend_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package main
+
+func suspendProcess() {
+	// Process suspension via SIGTSTP is not supported on Windows
+}


### PR DESCRIPTION
----
## Summary by Gitar

- **Terminal Suspension:**
    - Added support for suspending the process via `Ctrl+Z` keybind with `suspend_unix.go` and `suspend_windows.go`.
    - Updated BubbleTea model to handle `ctrl+z` input for process suspension on non-Windows platforms.

<sub>This will update automatically on new commits.</sub>