### PR TITLE
Add proper timeout system

### DIFF
--- a/src/client/client.go
+++ b/src/client/client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -60,6 +61,10 @@ func NewClient(timeoutSeconds ...int) (tls_client.HttpClient, error) {
 
 	options := []tls_client.HttpClientOption{
 		tls_client.WithTimeoutSeconds(timeout),
+		tls_client.WithDialer(net.Dialer{
+			Timeout:   15 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}),
 		// Allow overriding TLS fingerprint via env; default stays Firefox_117.
 		tls_client.WithClientProfile(func() profiles.ClientProfile {
 			p := profiles.Firefox_148
@@ -91,13 +96,17 @@ func NewClient(timeoutSeconds ...int) (tls_client.HttpClient, error) {
 }
 
 func NewStandardHTTPClient(timeoutSeconds ...int) *http.Client {
-	timeout := 60 * time.Second
+	timeout := 600 * time.Second
 	if len(timeoutSeconds) > 0 && timeoutSeconds[0] > 0 {
 		timeout = time.Duration(timeoutSeconds[0]) * time.Second
 	}
 
 	transport := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   15 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
 	}
 
 	proxyAddr := GetProxyURL()

--- a/src/client/client_test.go
+++ b/src/client/client_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"net/http"
 	"os"
 	"testing"
 )
@@ -22,5 +23,31 @@ func TestNewStandardHTTPClient(t *testing.T) {
 	}
 	if c.Timeout.Seconds() != 30 {
 		t.Fatalf("expected timeout 30s, got %v", c.Timeout)
+	}
+
+	defaultClient := NewStandardHTTPClient()
+	if defaultClient.Timeout.Seconds() != 600 {
+		t.Fatalf("expected default timeout 600s, got %v", defaultClient.Timeout)
+	}
+
+	tr, ok := defaultClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatal("expected *http.Transport")
+	}
+	if tr.DialContext == nil {
+		t.Fatal("expected DialContext to be set")
+	}
+	if tr.ResponseHeaderTimeout != 0 {
+		t.Fatalf("expected ResponseHeaderTimeout to be 0, got %v", tr.ResponseHeaderTimeout)
+	}
+}
+
+func TestNewClient(t *testing.T) {
+	c, err := NewClient()
+	if err != nil {
+		t.Fatalf("unexpected error creating tls client: %v", err)
+	}
+	if c == nil {
+		t.Fatal("expected non-nil tls client")
 	}
 }


### PR DESCRIPTION
----
## Summary by Gitar

- **Timeout System:**
    - Added custom `net.Dialer` with timeout and keep-alive settings to `NewClient` and `NewStandardHTTPClient`
    - Increased standard HTTP client default timeout to `600` seconds and added `ResponseHeaderTimeout`
- **Tests:**
    - Added `TestNewClient` and expanded `TestNewStandardHTTPClient` to verify timeout configurations

<sub>This will update automatically on new commits.</sub>