### PR TITLE
Exit on Ctrl+C in y/n menu

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,11 +8,9 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"strings"
 	"syscall"
 
@@ -74,11 +72,7 @@ func (f *toolsFlagValue) IsBoolFlag() bool {
 }
 
 func restoreTerminal() {
-	if runtime.GOOS != "windows" {
-		rawModeOff := exec.Command("stty", "-raw", "echo")
-		rawModeOff.Stdin = os.Stdin
-		_ = rawModeOff.Run()
-	}
+	bubbletea.RestoreTerminal()
 }
 
 func loadConfig(configPath string) {

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -215,7 +216,10 @@ func runInteractiveShellMode(
 			output = helper.ExecuteCommandWithCapture(helper.ShellName, helper.ShellOptions, cmd, true, useAliases)
 			executed = true
 		} else {
-			confirmed, _ := bubbletea.ConfirmMenu(fmt.Sprintf("\nExecute shell command: `%s` ?", cmd), true)
+			confirmed, err := bubbletea.ConfirmMenu(fmt.Sprintf("\nExecute shell command: `%s` ?", cmd), true)
+			if errors.Is(err, bubbletea.ErrInterrupted) {
+				handleExit()
+			}
 			if confirmed {
 				output = helper.ExecuteCommandWithCapture(helper.ShellName, helper.ShellOptions, cmd, true, useAliases)
 				executed = true
@@ -301,7 +305,7 @@ func main() {
 	go func() {
 		<-terminate
 		restoreTerminal()
-		os.Exit(0)
+		os.Exit(130)
 	}()
 
 	apiModel := flag.String("model", "", "Choose which model to use")
@@ -892,6 +896,6 @@ func main() {
 func handleExit() {
 	bold.Println("Exiting...")
 	restoreTerminal()
-	os.Exit(0)
+	os.Exit(130)
 }
 

--- a/src/bubbletea/menu.go
+++ b/src/bubbletea/menu.go
@@ -2,17 +2,29 @@ package bubbletea
 
 import (
 	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
 )
 
+func RestoreTerminal() {
+	if runtime.GOOS != "windows" {
+		rawModeOff := exec.Command("stty", "-raw", "echo")
+		rawModeOff.Stdin = os.Stdin
+		_ = rawModeOff.Run()
+	}
+}
+
 type SelectModel struct {
-	Title    string
-	Options  []string
-	Cursor   int
-	Selected int
-	Canceled bool
+	Title       string
+	Options     []string
+	Cursor      int
+	Selected    int
+	Canceled    bool
+	Interrupted bool
 }
 
 func (m SelectModel) Init() tea.Cmd {
@@ -23,7 +35,10 @@ func (m SelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {
-		case "ctrl+c", "esc", "q":
+		case "ctrl+c":
+			m.Interrupted = true
+			return m, tea.Quit
+		case "esc", "q":
 			m.Canceled = true
 			return m, tea.Quit
 		case "up", "k":
@@ -103,7 +118,14 @@ func SelectMenu(title string, options []string, defaultIndex int) (int, string, 
 	}
 
 	res, ok := finalModel.(SelectModel)
-	if !ok || res.Canceled || res.Selected < 0 {
+	if !ok {
+		return -1, "", fmt.Errorf("selection failed")
+	}
+	if res.Interrupted {
+		RestoreTerminal()
+		os.Exit(0)
+	}
+	if res.Canceled || res.Selected < 0 {
 		return -1, "", fmt.Errorf("selection canceled")
 	}
 

--- a/src/bubbletea/menu.go
+++ b/src/bubbletea/menu.go
@@ -1,6 +1,7 @@
 package bubbletea
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -8,6 +9,11 @@ import (
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
+)
+
+var (
+	ErrInterrupted = errors.New("interrupted")
+	ErrCanceled    = errors.New("selection canceled")
 )
 
 func RestoreTerminal() {
@@ -94,7 +100,7 @@ func (m SelectModel) View() tea.View {
 }
 
 // SelectMenu runs an interactive selection menu using arrow keys and Enter.
-// Returns the selected index, selected option string, or error if canceled.
+// Returns the selected index, selected option string, or error if canceled or interrupted.
 func SelectMenu(title string, options []string, defaultIndex int) (int, string, error) {
 	if len(options) == 0 {
 		return -1, "", fmt.Errorf("no options provided")
@@ -122,11 +128,10 @@ func SelectMenu(title string, options []string, defaultIndex int) (int, string, 
 		return -1, "", fmt.Errorf("selection failed")
 	}
 	if res.Interrupted {
-		RestoreTerminal()
-		os.Exit(0)
+		return -1, "", ErrInterrupted
 	}
 	if res.Canceled || res.Selected < 0 {
-		return -1, "", fmt.Errorf("selection canceled")
+		return -1, "", ErrCanceled
 	}
 
 	return res.Selected, res.Options[res.Selected], nil

--- a/src/bubbletea/menu_test.go
+++ b/src/bubbletea/menu_test.go
@@ -61,6 +61,19 @@ func TestSelectModelCancel(t *testing.T) {
 	}
 }
 
+func TestSelectModelInterrupt(t *testing.T) {
+	m := SelectModel{
+		Title:   "Confirm",
+		Options: []string{"Yes", "No"},
+	}
+
+	updatedModel, _ := m.Update(tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl})
+	sm := updatedModel.(SelectModel)
+	if !sm.Interrupted {
+		t.Errorf("expected interrupted to be true after ctrl+c key")
+	}
+}
+
 func TestSelectModelView(t *testing.T) {
 	m := SelectModel{
 		Title:   "Confirm Action?",

--- a/src/helper/helper.go
+++ b/src/helper/helper.go
@@ -838,7 +838,11 @@ func HandleEachPart(resp *http.Response, input string, params structs.Params, ex
 						bubbletea.RestoreTerminal()
 						os.Exit(130)
 					}
-					toolOutput = cancelMsg
+					if cancelMsg != "" {
+						toolOutput = cancelMsg
+					} else {
+						toolOutput = confirmErr.Error()
+					}
 					err = confirmErr
 				} else if !proceed {
 					toolOutput = cancelMsg

--- a/src/helper/helper.go
+++ b/src/helper/helper.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -223,6 +224,10 @@ func (f *interactiveFormatter) writeText(text string) {
 func GetData(input string, params structs.Params, extraOptions structs.ExtraOptions) ([]interface{}, string) {
 	responseTxt, turnMessages, err := MakeRequestAndGetData(input, params, extraOptions)
 	if err != nil {
+		if errors.Is(err, bubbletea.ErrInterrupted) {
+			bubbletea.RestoreTerminal()
+			os.Exit(130)
+		}
 		return nil, ""
 	}
 
@@ -826,8 +831,16 @@ func HandleEachPart(resp *http.Response, input string, params structs.Params, ex
 
 				var toolOutput string
 				var err error
-				proceed, cancelMsg := tools.PreConfirm(preConfirmCtx, tc.Function.Name, tc.Function.Arguments)
-				if !proceed {
+				proceed, cancelMsg, confirmErr := tools.PreConfirm(preConfirmCtx, tc.Function.Name, tc.Function.Arguments)
+				if confirmErr != nil {
+					hideStatus()
+					if errors.Is(confirmErr, bubbletea.ErrInterrupted) {
+						bubbletea.RestoreTerminal()
+						os.Exit(130)
+					}
+					toolOutput = cancelMsg
+					err = confirmErr
+				} else if !proceed {
 					toolOutput = cancelMsg
 					err = fmt.Errorf("%s", cancelMsg)
 				} else {
@@ -1179,7 +1192,10 @@ func MakeRequestAndGetData(input string, params structs.Params, extraOptions str
 					fmt.Println()
 					ExecuteCommand(ShellName, ShellOptions, fullText)
 				} else {
-					confirmed, _ := bubbletea.ConfirmMenu("\nExecute shell command?", true)
+					confirmed, err := bubbletea.ConfirmMenu("\nExecute shell command?", true)
+					if errors.Is(err, bubbletea.ErrInterrupted) {
+						return "", nil, err
+					}
 					if confirmed {
 						ExecuteCommand(ShellName, ShellOptions, fullText)
 					} else {

--- a/src/mcp/wizard.go
+++ b/src/mcp/wizard.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -17,7 +18,21 @@ import (
 // SelectMenu runs an interactive selection menu using arrow keys and Enter.
 // Returns the selected index, selected option string, or error if canceled.
 func SelectMenu(title string, options []string, defaultIndex int) (int, string, error) {
-	return bubbletea.SelectMenu(title, options, defaultIndex)
+	idx, opt, err := bubbletea.SelectMenu(title, options, defaultIndex)
+	if errors.Is(err, bubbletea.ErrInterrupted) {
+		bubbletea.RestoreTerminal()
+		os.Exit(130)
+	}
+	return idx, opt, err
+}
+
+func ConfirmMenu(title string, defaultYes bool) (bool, error) {
+	confirmed, err := bubbletea.ConfirmMenu(title, defaultYes)
+	if errors.Is(err, bubbletea.ErrInterrupted) {
+		bubbletea.RestoreTerminal()
+		os.Exit(130)
+	}
+	return confirmed, err
 }
 
 // RemoveServerInteractive lists configured MCP servers in an interactive arrow-key menu
@@ -215,7 +230,7 @@ func AddServerInteractive(ctx context.Context, configPath string) error {
 			}
 		}
 
-		addAuth, _ := bubbletea.ConfirmMenu("▶ Add Authorization Bearer Token / API Key?", false)
+		addAuth, _ := ConfirmMenu("▶ Add Authorization Bearer Token / API Key?", false)
 		if addAuth {
 			fmt.Print("  Enter Bearer Token / API Key: ")
 			token, _ := readInput(reader)
@@ -232,7 +247,7 @@ func AddServerInteractive(ctx context.Context, configPath string) error {
 			}
 		}
 
-		addHeaders, _ := bubbletea.ConfirmMenu("▶ Add additional custom HTTP headers?", false)
+		addHeaders, _ := ConfirmMenu("▶ Add additional custom HTTP headers?", false)
 		if addHeaders {
 			for {
 				fmt.Print("  Header Name (or press Enter to finish): ")
@@ -260,7 +275,7 @@ func AddServerInteractive(ctx context.Context, configPath string) error {
 	initErr := testMgr.InitServer(ctx, name, sc)
 	if initErr != nil {
 		fmt.Printf("\n⚠️  Connection test warning: %v\n", initErr)
-		saveAnyway, _ := bubbletea.ConfirmMenu("Do you still want to save this server configuration?", false)
+		saveAnyway, _ := ConfirmMenu("Do you still want to save this server configuration?", false)
 		if !saveAnyway {
 			fmt.Println("Aborted without saving.")
 			return nil

--- a/src/search/search.go
+++ b/src/search/search.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -741,7 +742,11 @@ func ConfirmSearchExecution(params SearchParams, autoConfirm bool, isQuiet bool,
 		return response == "y" || response == "yes"
 	}
 
-	confirmed, _ := bubbletea.ConfirmMenu(title.String(), true)
+	confirmed, err := bubbletea.ConfirmMenu(title.String(), true)
+	if errors.Is(err, bubbletea.ErrInterrupted) {
+		bubbletea.RestoreTerminal()
+		os.Exit(130)
+	}
 	return confirmed
 }
 

--- a/src/tools/tools.go
+++ b/src/tools/tools.go
@@ -109,21 +109,20 @@ const ConfirmedKey contextKey = "confirmed"
 var bold = color.New(color.Bold)
 
 // confirmAction prompts the user with an interactive yes/no question using Bubble Tea.
-func confirmAction(prompt string) bool {
-	confirmed, _ := bubbletea.ConfirmMenu(prompt, true)
-	return confirmed
+func confirmAction(prompt string) (bool, error) {
+	return bubbletea.ConfirmMenu(prompt, true)
 }
 
 // PreConfirm performs any interactive confirmation required for a tool call
 // before execution begins. Callers should invoke this on an undeadlined
 // context (i.e. before starting a per-execution timeout) so that the time
 // spent waiting on user input does not count against the tool's execution
-// budget. It returns (proceed, message): if proceed is false, message
+// budget. It returns (proceed, message, err): if proceed is false, message
 // contains the cancellation message that should be returned as the tool's
 // result without running the handler at all.
-func PreConfirm(ctx context.Context, name string, argsJSON string) (bool, string) {
+func PreConfirm(ctx context.Context, name string, argsJSON string) (bool, string, error) {
 	if autoExec, _ := ctx.Value(AutoExecKey).(bool); autoExec {
-		return true, ""
+		return true, "", nil
 	}
 
 	var args map[string]any
@@ -134,21 +133,29 @@ func PreConfirm(ctx context.Context, name string, argsJSON string) (bool, string
 	switch name {
 	case "execute_command":
 		cmdStr, _ := args["command"].(string)
-		if !confirmAction(fmt.Sprintf("\nExecute tool shell command: `%s` ?", cmdStr)) {
-			return false, "Command execution cancelled by user."
+		confirmed, err := confirmAction(fmt.Sprintf("\nExecute tool shell command: `%s` ?", cmdStr))
+		if err != nil {
+			return false, "", err
+		}
+		if !confirmed {
+			return false, "Command execution cancelled by user.", nil
 		}
 	case "write_file":
 		filePath, _ := args["path"].(string)
 		if filePath != "" {
 			if _, err := os.Stat(filePath); err == nil {
-				if !confirmAction(fmt.Sprintf("\nFile `%s` already exists. Overwrite it?", filePath)) {
-					return false, "File overwrite cancelled by user."
+				confirmed, err := confirmAction(fmt.Sprintf("\nFile `%s` already exists. Overwrite it?", filePath))
+				if err != nil {
+					return false, "", err
+				}
+				if !confirmed {
+					return false, "File overwrite cancelled by user.", nil
 				}
 			}
 		}
 	}
 
-	return true, ""
+	return true, "", nil
 }
 
 func (r *Registry) Register(spec ToolSpec, handler ToolHandler) {
@@ -401,7 +408,11 @@ func (r *Registry) registerBuiltinTools(selectedTools ...string) {
 			autoExec, _ := ctx.Value(AutoExecKey).(bool)
 			confirmed, _ := ctx.Value(ConfirmedKey).(bool)
 			if !autoExec && !confirmed {
-				if !confirmAction(fmt.Sprintf("\nExecute tool shell command: `%s` ?", cmdStr)) {
+				c, err := confirmAction(fmt.Sprintf("\nExecute tool shell command: `%s` ?", cmdStr))
+				if err != nil {
+					return "", err
+				}
+				if !c {
 					return "Command execution cancelled by user.", nil
 				}
 			}
@@ -541,7 +552,11 @@ func (r *Registry) registerBuiltinTools(selectedTools ...string) {
 			confirmed, _ := ctx.Value(ConfirmedKey).(bool)
 			if !autoExec && !confirmed {
 				if _, err := os.Stat(filePath); err == nil {
-					if !confirmAction(fmt.Sprintf("\nFile `%s` already exists. Overwrite it?", filePath)) {
+					c, err := confirmAction(fmt.Sprintf("\nFile `%s` already exists. Overwrite it?", filePath))
+					if err != nil {
+						return "", err
+					}
+					if !c {
 						return "File overwrite cancelled by user.", nil
 					}
 				}

--- a/src/tools/tools.go
+++ b/src/tools/tools.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -135,6 +136,9 @@ func PreConfirm(ctx context.Context, name string, argsJSON string) (bool, string
 		cmdStr, _ := args["command"].(string)
 		confirmed, err := confirmAction(fmt.Sprintf("\nExecute tool shell command: `%s` ?", cmdStr))
 		if err != nil {
+			if errors.Is(err, bubbletea.ErrCanceled) {
+				return false, "Command execution cancelled by user.", nil
+			}
 			return false, "", err
 		}
 		if !confirmed {
@@ -146,6 +150,9 @@ func PreConfirm(ctx context.Context, name string, argsJSON string) (bool, string
 			if _, err := os.Stat(filePath); err == nil {
 				confirmed, err := confirmAction(fmt.Sprintf("\nFile `%s` already exists. Overwrite it?", filePath))
 				if err != nil {
+					if errors.Is(err, bubbletea.ErrCanceled) {
+						return false, "File overwrite cancelled by user.", nil
+					}
 					return false, "", err
 				}
 				if !confirmed {
@@ -410,6 +417,9 @@ func (r *Registry) registerBuiltinTools(selectedTools ...string) {
 			if !autoExec && !confirmed {
 				c, err := confirmAction(fmt.Sprintf("\nExecute tool shell command: `%s` ?", cmdStr))
 				if err != nil {
+					if errors.Is(err, bubbletea.ErrCanceled) {
+						return "Command execution cancelled by user.", nil
+					}
 					return "", err
 				}
 				if !c {
@@ -554,6 +564,9 @@ func (r *Registry) registerBuiltinTools(selectedTools ...string) {
 				if _, err := os.Stat(filePath); err == nil {
 					c, err := confirmAction(fmt.Sprintf("\nFile `%s` already exists. Overwrite it?", filePath))
 					if err != nil {
+						if errors.Is(err, bubbletea.ErrCanceled) {
+							return "File overwrite cancelled by user.", nil
+						}
 						return "", err
 					}
 					if !c {

--- a/src/tools/tools_test.go
+++ b/src/tools/tools_test.go
@@ -145,3 +145,14 @@ func TestParseToolList(t *testing.T) {
 		t.Fatalf("unexpected ParseToolList result for 'all': %v, %v", tools, ok)
 	}
 }
+
+func TestPreConfirmAutoExec(t *testing.T) {
+	ctx := context.WithValue(context.Background(), AutoExecKey, true)
+	proceed, msg, err := PreConfirm(ctx, "execute_command", `{"command": "echo test"}`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !proceed || msg != "" {
+		t.Fatalf("expected proceed true with empty msg, got %v, %q", proceed, msg)
+	}
+}


### PR DESCRIPTION
----
## Summary by Gitar

- **Interactive Menus:**
    - Added `Interrupted` state to handle `ctrl+c` separately from cancellation in `SelectModel`
    - Implemented `RestoreTerminal` and `os.Exit(0)` on interrupt to properly reset terminal state
- **Testing:**
    - Added `TestSelectModelInterrupt` to verify `ctrl+c` correctly triggers the interruption flow

<sub>This will update automatically on new commits.</sub>