### PR TITLE
Fix autoexec not being used in tool calls

### DIFF
--- a/main.go
+++ b/main.go
@@ -188,7 +188,7 @@ func runInteractiveShellMode(
 		params.ThreadID = threadID
 		params.SystemPrompt = systemPrompt
 
-		responseObjects, responseTxt := helper.GetData(input, params, structs.ExtraOptions{IsInteractiveShell: true, IsNormal: true})
+		responseObjects, responseTxt := helper.GetData(input, params, structs.ExtraOptions{IsInteractiveShell: true, IsNormal: true, AutoExec: shouldExecuteCommand})
 
 		if len(logFile) > 0 {
 			utils.LogToFile(responseTxt, "ASSISTANT_RESPONSE", logFile)
@@ -602,14 +602,14 @@ func main() {
 				}
 				helper.GetWholeText(
 					*preprompt+trimmedPrompt+contextText+pipedInput,
-					structs.ExtraOptions{IsGetWhole: *isWhole},
+					structs.ExtraOptions{IsGetWhole: *isWhole, AutoExec: *shouldExecuteCommand},
 					mainParams,
 				)
 			} else {
 				formattedInput := bubbletea.GetFormattedInputStdin()
 				helper.GetWholeText(
 					*preprompt+formattedInput+cleanPipedInput,
-					structs.ExtraOptions{IsGetWhole: *isWhole},
+					structs.ExtraOptions{IsGetWhole: *isWhole, AutoExec: *shouldExecuteCommand},
 					mainParams,
 				)
 			}
@@ -651,6 +651,7 @@ func main() {
 					structs.ExtraOptions{
 						IsGetCode:   true,
 						IsGetSilent: *isQuiet,
+						AutoExec:    *shouldExecuteCommand,
 					},
 				)
 			} else {
@@ -695,7 +696,7 @@ func main() {
 				mainParams.PrevMessages = previousMessages
 				mainParams.ThreadID = threadID
 
-				responseObjects, responseTxt := helper.GetData(input, mainParams, structs.ExtraOptions{IsInteractive: true, IsNormal: true, IsGetSilent: *isQuiet})
+				responseObjects, responseTxt := helper.GetData(input, mainParams, structs.ExtraOptions{IsInteractive: true, IsNormal: true, IsGetSilent: *isQuiet, AutoExec: *shouldExecuteCommand})
 
 				if len(*logFile) > 0 {
 					utils.LogToFile(responseTxt, "ASSISTANT_RESPONSE", *logFile)
@@ -755,7 +756,7 @@ func main() {
 					mainParams.PrevMessages = previousMessages
 					mainParams.ThreadID = threadID
 
-					responseObjects, responseTxt := helper.GetData(userInput, mainParams, structs.ExtraOptions{IsInteractive: true, IsNormal: true, IsGetSilent: *isQuiet})
+					responseObjects, responseTxt := helper.GetData(userInput, mainParams, structs.ExtraOptions{IsInteractive: true, IsNormal: true, IsGetSilent: *isQuiet, AutoExec: *shouldExecuteCommand})
 					previousMessages = append(previousMessages, responseObjects...)
 					lastResponse = responseTxt
 
@@ -791,6 +792,7 @@ func main() {
 					IsFind:         true,
 					Verbose:        *isVerbose,
 					SearchProvider: finalSearchProvider,
+					AutoExec:       *shouldExecuteCommand,
 				}
 
 				helper.SearchQuery(trimmedPrompt, mainParams, extraOptions, *isQuiet, *logFile)
@@ -811,6 +813,7 @@ func main() {
 				IsFind:            true,
 				Verbose:           *isVerbose,
 				SearchProvider:    finalSearchProvider,
+				AutoExec:          *shouldExecuteCommand,
 			}
 
 			getAndPrintFindResponse := helper.InteractiveFindSession(mainParams, extraOptions, *logFile, nil)
@@ -854,13 +857,13 @@ func main() {
 					utils.PrintError(`Example: tgpt -q "What is encryption?"`)
 					return
 				}
-				if _, _, err := helper.MakeRequestAndGetData(*preprompt+trimmedPrompt+contextText+pipedInput, mainParams, structs.ExtraOptions{IsGetSilent: true}); err != nil {
+				if _, _, err := helper.MakeRequestAndGetData(*preprompt+trimmedPrompt+contextText+pipedInput, mainParams, structs.ExtraOptions{IsGetSilent: true, AutoExec: *shouldExecuteCommand}); err != nil {
 					return
 				}
 			} else {
 				formattedInput := bubbletea.GetFormattedInputStdin()
 				fmt.Println()
-				if _, _, err := helper.MakeRequestAndGetData(*preprompt+formattedInput+cleanPipedInput, mainParams, structs.ExtraOptions{IsGetSilent: true}); err != nil {
+				if _, _, err := helper.MakeRequestAndGetData(*preprompt+formattedInput+cleanPipedInput, mainParams, structs.ExtraOptions{IsGetSilent: true, AutoExec: *shouldExecuteCommand}); err != nil {
 					return
 				}
 			}
@@ -877,7 +880,7 @@ func main() {
 				*preprompt+formattedInput+contextText+pipedInput,
 				mainParams,
 				structs.ExtraOptions{
-					IsNormal: true, IsInteractive: false, Verbose: *isVerbose,
+					IsNormal: true, IsInteractive: false, Verbose: *isVerbose, AutoExec: *shouldExecuteCommand,
 				})
 		}
 	} else {
@@ -889,7 +892,7 @@ func main() {
 		}
 		input := scanner.Text()
 		formattedInput := strings.TrimSpace(input)
-		helper.GetData(*preprompt+formattedInput+pipedInput, mainParams, structs.ExtraOptions{IsInteractive: false, IsNormal: true, Verbose: *isVerbose})
+		helper.GetData(*preprompt+formattedInput+pipedInput, mainParams, structs.ExtraOptions{IsInteractive: false, IsNormal: true, Verbose: *isVerbose, AutoExec: *shouldExecuteCommand})
 	}
 }
 

--- a/src/helper/helper.go
+++ b/src/helper/helper.go
@@ -1463,6 +1463,7 @@ func SearchQuery(input string, params structs.Params, extraOptions structs.Extra
 	searchOptions := structs.ExtraOptions{
 		IsNormal:    !isQuiet,
 		IsGetSilent: isQuiet,
+		AutoExec:    extraOptions.AutoExec,
 	}
 
 	queryWithContext := fmt.Sprintf("Here is the output of the search results: %s\n\nBased on these search results, answer the user's question: %s", searchResults, input)
@@ -1520,6 +1521,7 @@ func InteractiveFindSession(params structs.Params, extraOptions structs.ExtraOpt
 		responseObjects, responseTxt := GetData(input, params, structs.ExtraOptions{
 			IsInteractiveFind: true,
 			IsGetSilent:       true,
+			AutoExec:          extraOptions.AutoExec,
 		})
 		matches := searchRegex.FindStringSubmatch(responseTxt)
 
@@ -1553,7 +1555,7 @@ func InteractiveFindSession(params structs.Params, extraOptions structs.ExtraOpt
 			finalResponseObjects, finalResponseTxt := GetData(
 				fmt.Sprintf("Based on these search results, answer the user's question: %s", input),
 				params,
-				structs.ExtraOptions{IsInteractiveFind: true, IsNormal: true},
+				structs.ExtraOptions{IsInteractiveFind: true, IsNormal: true, AutoExec: extraOptions.AutoExec},
 			)
 
 			if len(logFile) > 0 {

--- a/src/helper/helper_test.go
+++ b/src/helper/helper_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/aandrew-me/tgpt/v2/src/structs"
+	"github.com/aandrew-me/tgpt/v2/src/tools"
 	http "github.com/bogdanfinn/fhttp"
 )
 
@@ -184,6 +185,56 @@ func TestToolDepthLimitClearsToolsAndReturnsResponse(t *testing.T) {
 
 	if res != "Final summary response" {
 		t.Errorf("expected response 'Final summary response', got %q", res)
+	}
+}
+
+func TestToolExecutionAutoExec(t *testing.T) {
+	step := 0
+	server := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		if step == 0 {
+			step++
+			resp := `{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"execute_command","arguments":"{\"command\":\"echo auto_exec_test\"}"}}]}}]}`
+			_, _ = w.Write([]byte("data: " + resp + "\n\n"))
+		} else {
+			resp := `{"choices":[{"delta":{"content":"Command executed successfully"}}]} `
+			_, _ = w.Write([]byte("data: " + resp + "\n\n"))
+		}
+	}))
+	defer server.Close()
+
+	tools.DefaultRegistry.RegisterBuiltinTools("execute_command")
+
+	params := structs.Params{
+		Provider: "openai",
+		Url:      server.URL,
+		Tools:    tools.DefaultRegistry.GetOpenAITools(),
+	}
+	extraOptions := structs.ExtraOptions{
+		IsNormal: true,
+		AutoExec: true,
+	}
+
+	res, turnMsgs, err := MakeRequestAndGetData("run command", params, extraOptions)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(res, "Command executed successfully") {
+		t.Errorf("expected response to contain 'Command executed successfully', got %q", res)
+	}
+
+	foundToolResult := false
+	for _, msg := range turnMsgs {
+		if tm, ok := msg.(structs.ToolMessage); ok {
+			if strings.Contains(tm.Content, "auto_exec_test") {
+				foundToolResult = true
+				break
+			}
+		}
+	}
+	if !foundToolResult {
+		t.Errorf("expected turn messages to contain tool result with auto_exec_test, got %#v", turnMsgs)
 	}
 }
 


### PR DESCRIPTION
----
## Summary by Gitar

- **Bug Fixes:**
    - Passed `AutoExec` flag to `ExtraOptions` across various commands and modes in `main.go` and `helper.go`
- **Tests:**
    - Added `TestToolExecutionAutoExec` in `helper_test.go` to verify correct automatic command execution in tool calls

<sub>This will update automatically on new commits.</sub>