### PR TITLE
Append support for write_file, new edit_file tool

### DIFF
--- a/src/helper/helper.go
+++ b/src/helper/helper.go
@@ -1268,7 +1268,7 @@ func ShowHelpMessage() {
 	fmt.Printf("%-50v Set Provider. Detailed information has been provided below. (Env: AI_PROVIDER for chat and IMG_PROVIDER for image gen.)\n", "--provider")
 	fmt.Printf("%-50v Find information using web search \n", "-f, --find")
 	fmt.Printf("%-50v Search provider for web search: exa (default) or google (Env: SEARCH_PROVIDER).\n%-50v Exa works without api key with rate limits and supports EXA_API_KEY env variable.\n%-50v google requires TGPT_GOOGLE_API_KEY and TGPT_GOOGLE_SEARCH_ENGINE_ID env variables.\n%-50s Check SEARCH_SETUP.md for google: https://github.com/aandrew-me/tgpt/blob/main/SEARCH_SETUP.md\n", "--search-provider", "", "", "")
-	fmt.Printf("%-50v Enable built-in tool calling (all or comma-separated list: web_search_exa, web_search_firecrawl, read_directory, read_file, execute_command, web_fetch, write_file)\n", "-t, --tools [tools]")
+	fmt.Printf("%-50v Enable built-in tool calling (all or comma-separated list: web_search_exa, web_search_firecrawl, read_directory, read_file, execute_command, web_fetch, write_file, edit_file)\n", "-t, --tools [tools]")
 	fmt.Printf("%-50v Enable MCP (Model Context Protocol) and auto-detect configuration file\n", "--mcp")
 	fmt.Printf("%-50v Path to MCP server configuration JSON file (Env: MCP_CONFIG). See 'Tool calling & MCP' section below.\n", "--mcp-config")
 	fmt.Printf("%-50v Command to run a stdio MCP server directly, e.g. --mcp-server \"npx -y some-mcp-server\"\n", "--mcp-server")
@@ -1375,6 +1375,7 @@ func ShowHelpMessage() {
 	fmt.Println("execute_command      Execute a shell command")
 	fmt.Println("web_fetch            Fetch the contents of a webpage or URL")
 	fmt.Println("write_file           Write content to a file")
+	fmt.Println("edit_file            Edit a file by replacing old_content with new_content")
 
 	bold.Println("\nMCP servers:")
 	fmt.Println("Use --mcp to enable MCP and auto-detect configuration file, --mcp-config to specify a JSON file, or --mcp-server to run a single stdio MCP server directly.")

--- a/src/tools/tools.go
+++ b/src/tools/tools.go
@@ -59,6 +59,7 @@ var AllBuiltinTools = []string{
 	"execute_command",
 	"web_fetch",
 	"write_file",
+	"edit_file",
 }
 
 func IsBuiltinTool(name string) bool {
@@ -146,17 +147,43 @@ func PreConfirm(ctx context.Context, name string, argsJSON string) (bool, string
 		}
 	case "write_file":
 		filePath, _ := args["path"].(string)
+		appendMode, _ := args["append"].(bool)
 		if filePath != "" {
 			if _, err := os.Stat(filePath); err == nil {
-				confirmed, err := confirmAction(fmt.Sprintf("\nFile `%s` already exists. Overwrite it?", filePath))
+				var prompt string
+				var cancelMsg string
+				if appendMode {
+					prompt = fmt.Sprintf("\nAppend to file `%s` ?", filePath)
+					cancelMsg = "File append cancelled by user."
+				} else {
+					prompt = fmt.Sprintf("\nFile `%s` already exists. Overwrite it?", filePath)
+					cancelMsg = "File overwrite cancelled by user."
+				}
+				confirmed, err := confirmAction(prompt)
 				if err != nil {
 					if errors.Is(err, bubbletea.ErrCanceled) {
-						return false, "File overwrite cancelled by user.", nil
+						return false, cancelMsg, nil
 					}
 					return false, "", err
 				}
 				if !confirmed {
-					return false, "File overwrite cancelled by user.", nil
+					return false, cancelMsg, nil
+				}
+			}
+		}
+	case "edit_file":
+		filePath, _ := args["path"].(string)
+		if filePath != "" {
+			if _, err := os.Stat(filePath); err == nil {
+				confirmed, err := confirmAction(fmt.Sprintf("\nEdit file `%s` ?", filePath))
+				if err != nil {
+					if errors.Is(err, bubbletea.ErrCanceled) {
+						return false, "File edit cancelled by user.", nil
+					}
+					return false, "", err
+				}
+				if !confirmed {
+					return false, "File edit cancelled by user.", nil
 				}
 			}
 		}
@@ -544,6 +571,10 @@ func (r *Registry) registerBuiltinTools(selectedTools ...string) {
 							"type":        "string",
 							"description": "Content to write to the file",
 						},
+						"append": map[string]any{
+							"type":        "boolean",
+							"description": "If true, append content to the file instead of overwriting it (defaults to false)",
+						},
 					},
 					"required": []string{"path", "content"},
 				},
@@ -557,20 +588,30 @@ func (r *Registry) registerBuiltinTools(selectedTools ...string) {
 			if !ok {
 				return "", fmt.Errorf("content parameter is required")
 			}
+			appendMode, _ := args["append"].(bool)
 
 			autoExec, _ := ctx.Value(AutoExecKey).(bool)
 			confirmed, _ := ctx.Value(ConfirmedKey).(bool)
 			if !autoExec && !confirmed {
 				if _, err := os.Stat(filePath); err == nil {
-					c, err := confirmAction(fmt.Sprintf("\nFile `%s` already exists. Overwrite it?", filePath))
+					var prompt string
+					var cancelMsg string
+					if appendMode {
+						prompt = fmt.Sprintf("\nAppend to file `%s` ?", filePath)
+						cancelMsg = "File append cancelled by user."
+					} else {
+						prompt = fmt.Sprintf("\nFile `%s` already exists. Overwrite it?", filePath)
+						cancelMsg = "File overwrite cancelled by user."
+					}
+					c, err := confirmAction(prompt)
 					if err != nil {
 						if errors.Is(err, bubbletea.ErrCanceled) {
-							return "File overwrite cancelled by user.", nil
+							return cancelMsg, nil
 						}
 						return "", err
 					}
 					if !c {
-						return "File overwrite cancelled by user.", nil
+						return cancelMsg, nil
 					}
 				}
 			}
@@ -582,11 +623,111 @@ func (r *Registry) registerBuiltinTools(selectedTools ...string) {
 				}
 			}
 
+			if appendMode {
+				f, err := os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+				if err != nil {
+					return "", fmt.Errorf("failed to open file for appending: %w", err)
+				}
+				defer f.Close()
+				if _, err := f.WriteString(content); err != nil {
+					return "", fmt.Errorf("failed to append to file: %w", err)
+				}
+				return fmt.Sprintf("Successfully appended to %s", filePath), nil
+			}
+
 			if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
 				return "", fmt.Errorf("failed to write file: %w", err)
 			}
 
 			return fmt.Sprintf("Successfully wrote to %s", filePath), nil
+		})
+	}
+
+	// 7. edit_file
+	if shouldRegister("edit_file") {
+		r.Register(ToolSpec{
+			Type: "function",
+			Function: FunctionSpec{
+				Name:        "edit_file",
+				Description: "Edit a file by replacing old_content with new_content",
+				Parameters: map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"path": map[string]any{
+							"type":        "string",
+							"description": "Path to the file to edit",
+						},
+						"old_content": map[string]any{
+							"type":        "string",
+							"description": "Exact text or code block in the file to be replaced",
+						},
+						"new_content": map[string]any{
+							"type":        "string",
+							"description": "New text or code block to replace old_content with",
+						},
+					},
+					"required": []string{"path", "old_content", "new_content"},
+				},
+			},
+		}, func(ctx context.Context, args map[string]any) (string, error) {
+			filePath, _ := args["path"].(string)
+			if filePath == "" {
+				return "", fmt.Errorf("path parameter is required")
+			}
+			oldContent, ok := args["old_content"].(string)
+			if !ok {
+				return "", fmt.Errorf("old_content parameter is required")
+			}
+			if oldContent == "" {
+				return "", fmt.Errorf("old_content parameter cannot be empty")
+			}
+			newContent, ok := args["new_content"].(string)
+			if !ok {
+				return "", fmt.Errorf("new_content parameter is required")
+			}
+			if oldContent == newContent {
+				return "", fmt.Errorf("old_content and new_content are identical; no changes to make")
+			}
+
+			if _, err := os.Stat(filePath); err != nil {
+				return "", fmt.Errorf("failed to read file for editing: %w", err)
+			}
+
+			autoExec, _ := ctx.Value(AutoExecKey).(bool)
+			confirmed, _ := ctx.Value(ConfirmedKey).(bool)
+			if !autoExec && !confirmed {
+				c, err := confirmAction(fmt.Sprintf("\nEdit file `%s` ?", filePath))
+				if err != nil {
+					if errors.Is(err, bubbletea.ErrCanceled) {
+						return "File edit cancelled by user.", nil
+					}
+					return "", err
+				}
+				if !c {
+					return "File edit cancelled by user.", nil
+				}
+			}
+
+			data, err := os.ReadFile(filePath)
+			if err != nil {
+				return "", fmt.Errorf("failed to read file for editing: %w", err)
+			}
+
+			fileStr := string(data)
+			count := strings.Count(fileStr, oldContent)
+			if count == 0 {
+				return "", fmt.Errorf("old_content not found in %s", filePath)
+			}
+			if count > 1 {
+				return "", fmt.Errorf("old_content appears %d times in %s; please provide more surrounding context to make it unique", count, filePath)
+			}
+
+			updatedStr := strings.Replace(fileStr, oldContent, newContent, 1)
+			if err := os.WriteFile(filePath, []byte(updatedStr), 0644); err != nil {
+				return "", fmt.Errorf("failed to write edited file: %w", err)
+			}
+
+			return fmt.Sprintf("Successfully edited %s", filePath), nil
 		})
 	}
 }

--- a/src/tools/tools_test.go
+++ b/src/tools/tools_test.go
@@ -87,7 +87,7 @@ func TestWriteFileTool(t *testing.T) {
 	argsJSON := `{"path": "` + escapedPath + `", "content": "` + expectedContent + `"}`
 	res, err := r.Execute(context.Background(), "write_file", argsJSON)
 	if err != nil {
-		t.Fatalf("unexpected error executing write_file: %v", err)
+		t.Fatalf("unexpected error executing write_file for new file: %v", err)
 	}
 	if !strings.Contains(res, "Successfully wrote") {
 		t.Fatalf("expected success message, got %q", res)
@@ -154,5 +154,127 @@ func TestPreConfirmAutoExec(t *testing.T) {
 	}
 	if !proceed || msg != "" {
 		t.Fatalf("expected proceed true with empty msg, got %v, %q", proceed, msg)
+	}
+}
+
+func TestPreConfirmNewFileNoPrompt(t *testing.T) {
+	dir := t.TempDir()
+	newPath := filepath.Join(dir, "non_existent_file.txt")
+	escapedPath := strings.ReplaceAll(newPath, `\`, `\\`)
+	proceed, msg, err := PreConfirm(context.Background(), "write_file", `{"path": "`+escapedPath+`"}`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !proceed || msg != "" {
+		t.Fatalf("expected proceed true without confirmation for new file, got %v, %q", proceed, msg)
+	}
+}
+
+func TestWriteFileAppendMode(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "append_test.txt")
+	if err := os.WriteFile(filePath, []byte("Hello "), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	r := NewRegistry()
+	r.RegisterBuiltinTools()
+
+	escapedPath := strings.ReplaceAll(filePath, `\`, `\\`)
+	ctx := context.WithValue(context.Background(), AutoExecKey, true)
+	argsJSON := `{"path": "` + escapedPath + `", "content": "world!", "append": true}`
+
+	res, err := r.Execute(ctx, "write_file", argsJSON)
+	if err != nil {
+		t.Fatalf("unexpected error executing write_file in append mode: %v", err)
+	}
+	if !strings.Contains(res, "Successfully appended") {
+		t.Fatalf("expected append success message, got %q", res)
+	}
+
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("failed to read back appended file: %v", err)
+	}
+	if string(content) != "Hello world!" {
+		t.Fatalf("expected 'Hello world!', got %q", string(content))
+	}
+}
+
+func TestEditFileTool(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "edit_test.txt")
+	initialContent := "func foo() {\n\treturn 1\n}\n"
+	if err := os.WriteFile(filePath, []byte(initialContent), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	r := NewRegistry()
+	r.RegisterBuiltinTools()
+	if !r.Has("edit_file") {
+		t.Fatal("expected registry to have edit_file tool")
+	}
+
+	escapedPath := strings.ReplaceAll(filePath, `\`, `\\`)
+	ctx := context.WithValue(context.Background(), AutoExecKey, true)
+
+	// Successful edit
+	argsJSON := `{"path": "` + escapedPath + `", "old_content": "return 1", "new_content": "return 42"}`
+	res, err := r.Execute(ctx, "edit_file", argsJSON)
+	if err != nil {
+		t.Fatalf("unexpected error executing edit_file: %v", err)
+	}
+	if !strings.Contains(res, "Successfully edited") {
+		t.Fatalf("expected edit success message, got %q", res)
+	}
+
+	readBack, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("failed to read back edited file: %v", err)
+	}
+	expected := "func foo() {\n\treturn 42\n}\n"
+	if string(readBack) != expected {
+		t.Fatalf("expected %q, got %q", expected, string(readBack))
+	}
+
+	// Target old_content not found error
+	notFoundJSON := `{"path": "` + escapedPath + `", "old_content": "non_existent_code", "new_content": "something"}`
+	_, err = r.Execute(ctx, "edit_file", notFoundJSON)
+	if err == nil || !strings.Contains(err.Error(), "old_content not found") {
+		t.Fatalf("expected 'old_content not found' error, got %v", err)
+	}
+
+	// Multiple matches error
+	multiContent := "foo\nfoo\n"
+	if err := os.WriteFile(filePath, []byte(multiContent), 0644); err != nil {
+		t.Fatalf("failed to write multi-match file: %v", err)
+	}
+	multiJSON := `{"path": "` + escapedPath + `", "old_content": "foo", "new_content": "bar"}`
+	_, err = r.Execute(ctx, "edit_file", multiJSON)
+	if err == nil || !strings.Contains(err.Error(), "appears 2 times") {
+		t.Fatalf("expected multiple matches error, got %v", err)
+	}
+
+	// Identical old_content and new_content error
+	identicalJSON := `{"path": "` + escapedPath + `", "old_content": "foo", "new_content": "foo"}`
+	_, err = r.Execute(ctx, "edit_file", identicalJSON)
+	if err == nil || !strings.Contains(err.Error(), "identical") {
+		t.Fatalf("expected identical content error, got %v", err)
+	}
+
+	// Non-existent file edit error
+	missingPath := filepath.Join(dir, "does_not_exist.txt")
+	escapedMissing := strings.ReplaceAll(missingPath, `\`, `\\`)
+	missingJSON := `{"path": "` + escapedMissing + `", "old_content": "a", "new_content": "b"}`
+
+	// PreConfirm should return proceed true without prompting for missing file
+	proceed, msg, confirmErr := PreConfirm(context.Background(), "edit_file", missingJSON)
+	if confirmErr != nil || !proceed || msg != "" {
+		t.Fatalf("expected PreConfirm to skip prompt for missing file, got proceed=%v, msg=%q, err=%v", proceed, msg, confirmErr)
+	}
+
+	_, err = r.Execute(ctx, "edit_file", missingJSON)
+	if err == nil || !strings.Contains(err.Error(), "failed to read file for editing") {
+		t.Fatalf("expected failed to read file error, got %v", err)
 	}
 }


### PR DESCRIPTION
----
## Summary by Gitar

- **New tools and features:**
    - Added `edit_file` tool to modify existing files by replacing `old_content` with `new_content`
    - Added `append` parameter support to `write_file` tool
- **Testing and documentation:**
    - Added comprehensive unit tests for `edit_file` and `write_file` append mode in `tools_test.go`
    - Updated help messages to include `edit_file` in the built-in tools list

<sub>This will update automatically on new commits.</sub>