### PR TITLE
Add Atlas Cloud provider

### DIFF
--- a/md/providers.md
+++ b/md/providers.md
@@ -1,6 +1,7 @@
 ### Currently available providers
 
 - [AnyAPI](https://docs.anyapi.ai/) (Multi-model API, 100k free anytokens/day, supports chat and image gen, many providers including deepseek, google, openai)
+- [Atlas Cloud](https://www.atlascloud.ai/) (OpenAI-compatible API, requires `ATLASCLOUD_API_KEY`, default model `qwen/qwen3.8-max`, supports `ATLASCLOUD_MODEL`, `ATLASCLOUD_URL`, and `ATLASCLOUD_BASE_URL`)
 - [Deepseek](https://www.deepseek.com/) (Requires API key)
 - [Groq](https://groq.com/) (Requires a free API Key. [Many models](https://console.groq.com/docs/models))
 - [Isou](https://isou.chat/) (Free) (Deepseek-chat with SEARXNG)

--- a/src/helper/helper.go
+++ b/src/helper/helper.go
@@ -1305,10 +1305,13 @@ func ShowHelpMessage() {
 
 	boldBlue.Println("\nProviders:")
 	fmt.Println("The default provider is opencode. The AI_PROVIDER environment variable can be used to specify a different provider.")
-	fmt.Println("Available providers to use: anyapi, deepseek, gemini, groq, isou, koboldai, minimax, ollama, ollamacloud, omniroute, openai, opencode, pollinations, powerbrain.")
+	fmt.Println("Available providers to use: anyapi, atlascloud, deepseek, gemini, groq, isou, koboldai, minimax, ollama, ollamacloud, omniroute, openai, opencode, pollinations, powerbrain.")
 
 	bold.Println("\nProvider: anyapi")
 	fmt.Println("Multi-model API with 100k free anytokens per day. Recognizes ANYAPI_API_KEY and ANYAPI_MODEL env vars. Default model: openai/gpt-4o-mini. Supports chat and image generation. Docs: https://docs.anyapi.ai/")
+
+	bold.Println("\nProvider: atlascloud")
+	fmt.Println("OpenAI-compatible Atlas Cloud API. Recognizes ATLASCLOUD_API_KEY, ATLASCLOUD_MODEL, ATLASCLOUD_URL and ATLASCLOUD_BASE_URL env vars. Default model: qwen/qwen3.8-max. Docs: https://www.atlascloud.ai/")
 
 	bold.Println("Provider: aihorde")
 	fmt.Println("A free, community-powered generation service: volunteers share spare computer power so anyone can generate images and text. Supports AIHORDE_MODEL and AIHORDE_API_KEY env variables. Site: https://aihorde.net/")

--- a/src/providers/atlascloud/atlascloud.go
+++ b/src/providers/atlascloud/atlascloud.go
@@ -1,0 +1,120 @@
+package atlascloud
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	http "github.com/bogdanfinn/fhttp"
+
+	"github.com/aandrew-me/tgpt/v2/src/client"
+	"github.com/aandrew-me/tgpt/v2/src/structs"
+)
+
+const (
+	defaultModel = "qwen/qwen3.8-max"
+	defaultURL   = "https://api.atlascloud.ai/v1/chat/completions"
+)
+
+type RequestBody struct {
+	Model    string `json:"model"`
+	Stream   bool   `json:"stream"`
+	Messages []any  `json:"messages"`
+	Tools    []any  `json:"tools,omitempty"`
+}
+
+func model(params structs.Params) string {
+	if params.ApiModel != "" {
+		return params.ApiModel
+	}
+	if value := os.Getenv("ATLASCLOUD_MODEL"); value != "" {
+		return value
+	}
+	return defaultModel
+}
+
+func apiKey(params structs.Params) string {
+	if params.ApiKey != "" {
+		return params.ApiKey
+	}
+	if value := os.Getenv("ATLASCLOUD_API_KEY"); value != "" {
+		return value
+	}
+	return os.Getenv("AI_API_KEY")
+}
+
+func endpoint(params structs.Params) string {
+	if params.Url != "" {
+		return params.Url
+	}
+	if value := os.Getenv("ATLASCLOUD_URL"); value != "" {
+		return value
+	}
+	if value := os.Getenv("ATLASCLOUD_BASE_URL"); value != "" {
+		return strings.TrimSuffix(value, "/") + "/chat/completions"
+	}
+	return defaultURL
+}
+
+func NewRequest(input string, params structs.Params) (*http.Response, error) {
+	httpClient, err := client.NewClient()
+	if err != nil {
+		return nil, fmt.Errorf("create client: %w", err)
+	}
+
+	messages := make([]any, 0, len(params.PrevMessages)+2)
+	if params.SystemPrompt != "" {
+		messages = append(messages, structs.DefaultMessage{
+			Content: params.SystemPrompt,
+			Role:    "system",
+		})
+	}
+	messages = append(messages, params.PrevMessages...)
+	if input != "" {
+		messages = append(messages, structs.DefaultMessage{
+			Role:    "user",
+			Content: input,
+		})
+	}
+
+	requestInfo := RequestBody{
+		Model:    model(params),
+		Stream:   true,
+		Messages: messages,
+		Tools:    params.Tools,
+	}
+	jsonRequest, err := json.Marshal(requestInfo)
+	if err != nil {
+		log.Fatal("Failed to build user request")
+	}
+
+	req, err := http.NewRequest("POST", endpoint(params), bytes.NewBuffer(jsonRequest))
+	if err != nil {
+		return nil, fmt.Errorf("create Atlas Cloud request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if key := apiKey(params); key != "" {
+		req.Header.Set("Authorization", "Bearer "+key)
+	}
+
+	return httpClient.Do(req)
+}
+
+func GetMainText(line string) string {
+	obj, ok := strings.CutPrefix(line, "data: ")
+	if !ok || obj == "[DONE]" {
+		return ""
+	}
+
+	var response structs.CommonResponse
+	if err := json.Unmarshal([]byte(obj), &response); err != nil {
+		return ""
+	}
+	if len(response.Choices) == 0 {
+		return ""
+	}
+	return response.Choices[0].Delta.Content
+}

--- a/src/providers/atlascloud/atlascloud_test.go
+++ b/src/providers/atlascloud/atlascloud_test.go
@@ -1,0 +1,77 @@
+package atlascloud
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/aandrew-me/tgpt/v2/src/structs"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfiguration(t *testing.T) {
+	t.Setenv("ATLASCLOUD_API_KEY", "atlas-key")
+	t.Setenv("ATLASCLOUD_MODEL", "atlas-model")
+	t.Setenv("ATLASCLOUD_BASE_URL", "https://example.com/v1/")
+
+	params := structs.Params{}
+	assert.Equal(t, "atlas-key", apiKey(params))
+	assert.Equal(t, "atlas-model", model(params))
+	assert.Equal(t, "https://example.com/v1/chat/completions", endpoint(params))
+
+	params = structs.Params{ApiKey: "flag-key", ApiModel: "flag-model", Url: "https://override.test/chat"}
+	assert.Equal(t, "flag-key", apiKey(params))
+	assert.Equal(t, "flag-model", model(params))
+	assert.Equal(t, "https://override.test/chat", endpoint(params))
+}
+
+func TestDefaults(t *testing.T) {
+	t.Setenv("ATLASCLOUD_API_KEY", "")
+	t.Setenv("AI_API_KEY", "")
+	t.Setenv("ATLASCLOUD_MODEL", "")
+	t.Setenv("ATLASCLOUD_URL", "")
+	t.Setenv("ATLASCLOUD_BASE_URL", "")
+
+	assert.Equal(t, defaultModel, model(structs.Params{}))
+	assert.Equal(t, defaultURL, endpoint(structs.Params{}))
+}
+
+func TestRequestBody(t *testing.T) {
+	body := RequestBody{
+		Model:  defaultModel,
+		Stream: true,
+		Messages: []any{
+			structs.DefaultMessage{Role: "user", Content: "Hello"},
+		},
+		Tools: []any{map[string]any{"type": "function"}},
+	}
+
+	encoded, err := json.Marshal(body)
+	assert.NoError(t, err)
+
+	var decoded map[string]any
+	assert.NoError(t, json.Unmarshal(encoded, &decoded))
+	assert.Equal(t, defaultModel, decoded["model"])
+	assert.Equal(t, true, decoded["stream"])
+	assert.Len(t, decoded["messages"], 1)
+	assert.Len(t, decoded["tools"], 1)
+}
+
+func TestGetMainText(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want string
+	}{
+		{"content", `data: {"choices":[{"delta":{"content":"Hello"}}]}`, "Hello"},
+		{"done", "data: [DONE]", ""},
+		{"empty choices", `data: {"choices":[]}`, ""},
+		{"malformed", "data: {", ""},
+		{"not data", `{"choices":[{"delta":{"content":"ignored"}}]}`, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, GetMainText(tt.line))
+		})
+	}
+}

--- a/src/providers/providers.go
+++ b/src/providers/providers.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aandrew-me/tgpt/v2/src/providers/aihorde"
 	"github.com/aandrew-me/tgpt/v2/src/providers/anyapi"
+	"github.com/aandrew-me/tgpt/v2/src/providers/atlascloud"
 	"github.com/aandrew-me/tgpt/v2/src/providers/deepseek"
 	"github.com/aandrew-me/tgpt/v2/src/providers/gemini"
 	"github.com/aandrew-me/tgpt/v2/src/providers/groq"
@@ -15,8 +16,8 @@ import (
 	"github.com/aandrew-me/tgpt/v2/src/providers/minimax"
 	"github.com/aandrew-me/tgpt/v2/src/providers/ollama"
 	"github.com/aandrew-me/tgpt/v2/src/providers/omniroute"
-	"github.com/aandrew-me/tgpt/v2/src/providers/opencode"
 	"github.com/aandrew-me/tgpt/v2/src/providers/openai"
+	"github.com/aandrew-me/tgpt/v2/src/providers/opencode"
 	"github.com/aandrew-me/tgpt/v2/src/providers/pollinations"
 	"github.com/aandrew-me/tgpt/v2/src/providers/powerbrain"
 	"github.com/aandrew-me/tgpt/v2/src/structs"
@@ -24,7 +25,7 @@ import (
 )
 
 var AvailableProviders = []string{
-	"anyapi", "aihorde", "deepseek", "isou", "gemini", "groq", "koboldai", "litellm", "minimax", "ollama", "ollamacloud", "omniroute", "opencode", "openai", "pollinations", "powerbrain",
+	"anyapi", "aihorde", "atlascloud", "deepseek", "isou", "gemini", "groq", "koboldai", "litellm", "minimax", "ollama", "ollamacloud", "omniroute", "opencode", "openai", "pollinations", "powerbrain",
 }
 
 func IsValidProvider(name string) bool {
@@ -41,7 +42,7 @@ func SupportsTools(provider string) bool {
 		provider = "opencode"
 	}
 	switch provider {
-	case "anyapi", "deepseek", "gemini", "groq", "litellm", "ollama", "omniroute", "opencode", "openai", "pollinations":
+	case "anyapi", "atlascloud", "deepseek", "gemini", "groq", "litellm", "ollama", "omniroute", "opencode", "openai", "pollinations":
 		return true
 	default:
 		return false
@@ -54,6 +55,8 @@ func GetMainText(line string, provider string, input string) string {
 		return aihorde.GetMainText(line)
 	case "anyapi":
 		return anyapi.GetMainText(line)
+	case "atlascloud":
+		return atlascloud.GetMainText(line)
 	case "deepseek":
 		return deepseek.GetMainText(line)
 	case "isou":
@@ -102,6 +105,8 @@ func NewRequest(input string, params structs.Params, extraOptions structs.ExtraO
 		return aihorde.NewRequest(input, params)
 	case "anyapi":
 		return anyapi.NewRequest(input, params)
+	case "atlascloud":
+		return atlascloud.NewRequest(input, params)
 	case "deepseek":
 		return deepseek.NewRequest(input, params)
 	case "gemini":

--- a/src/providers/providers_test.go
+++ b/src/providers/providers_test.go
@@ -3,7 +3,7 @@ package providers
 import "testing"
 
 func TestSupportsTools(t *testing.T) {
-	supported := []string{"openai", "opencode", "gemini", "groq", "deepseek", "ollama", "litellm", "omniroute", "anyapi", "pollinations", ""}
+	supported := []string{"openai", "opencode", "gemini", "groq", "deepseek", "ollama", "litellm", "omniroute", "anyapi", "atlascloud", "pollinations", ""}
 	for _, p := range supported {
 		if !SupportsTools(p) {
 			t.Errorf("expected provider %q to support tools", p)


### PR DESCRIPTION
## Summary

- add Atlas Cloud as a first-class OpenAI-compatible provider
- support Atlas-specific API key, model, URL, and base URL environment variables
- document the provider and cover configuration, request bodies, SSE parsing, registry, and tool support

## Testing

- `go test ./src/providers/atlascloud ./src/providers`
- `go build ./...`
- `go vet ./...`
- live CLI request: `tgpt --provider atlascloud --quiet ...` returned the expected response using `qwen/qwen3.8-max`

`go test ./...` also runs successfully outside two existing Windows package-manager assertions that fail on macOS; the same failures reproduce from the unmodified base commit.
